### PR TITLE
Fix missing salt/key derivation with static salt

### DIFF
--- a/examples/authorization_code.rs
+++ b/examples/authorization_code.rs
@@ -27,7 +27,7 @@ mod main {
             // Authorization tokens are 16 byte random keys to a memory hash map.
             Storage::new(RandomGenerator::new(16)),
             // Bearer tokens are signed (but not encrypted) using a passphrase.
-            TokenSigner::new_from_passphrase(passphrase));
+            TokenSigner::new_from_passphrase(passphrase, None));
 
         // Register a dummy client instance
         let client = Client::public("LocalClient", // Client id

--- a/src/iron/mod.rs
+++ b/src/iron/mod.rs
@@ -24,7 +24,7 @@
 //!         // Authorization tokens are 16 byte random keys to a memory hash map.
 //!         Storage::new(RandomGenerator::new(16)),
 //!         // Bearer tokens are signed (but not encrypted) using a passphrase.
-//!         TokenSigner::new_from_passphrase(passphrase));
+//!         TokenSigner::new_from_passphrase(passphrase, None));
 //!
 //!     // Register a dummy client instance
 //!     let client = Client::public("LocalClient", // Client id

--- a/src/primitives/issuer.rs
+++ b/src/primitives/issuer.rs
@@ -114,6 +114,9 @@ impl TokenSigner {
 
     /// Construct a signing instance from a passphrase, deriving a signing key in the process.
     ///
+    /// The salting_key SHOULD be changed to a self-generated one where possible instead of
+    /// relying on the default key. However, at that point fully switching to private
+    /// SigningKey instances is possibly a better option.
     pub fn new_from_passphrase(passwd: &str, salting_key: Option<SigningKey>) -> TokenSigner {
         // Default salt if none was provided, generated with `openssl rand 32`
         let salting_key = salting_key.unwrap_or_else(|| {

--- a/src/primitives/issuer.rs
+++ b/src/primitives/issuer.rs
@@ -11,7 +11,7 @@ use super::Time;
 use super::grant::{Grant, GrantRef, GrantRequest};
 use super::generator::{TokenGenerator, Assertion};
 use ring::digest::SHA256;
-use ring::hkdf::extract_and_expand;
+use ring::pbkdf2::derive as key_derive;
 use ring::hmac::SigningKey;
 
 /// Issuers create bearer tokens.
@@ -114,23 +114,27 @@ impl TokenSigner {
 
     /// Construct a signing instance from a passphrase, deriving a signing key in the process.
     ///
-    /// The salting_key SHOULD be changed to a self-generated one where possible instead of
-    /// relying on the default key. However, at that point fully switching to private
-    /// SigningKey instances is possibly a better option.
-    pub fn new_from_passphrase(passwd: &str, salting_key: Option<SigningKey>) -> TokenSigner {
+    /// The use of this function is DISCOURAGED.
+    ///
+    /// The salt SHOULD be changed to a self-generated one where possible instead of
+    /// relying on the default one which was generated as 32 random bytes with openssl.
+    /// However, at that point fully switching to private SigningKey instances is possibly
+    /// a better option.
+    pub fn new_from_passphrase(passwd: &str, salt: Option<&[u8]>) -> TokenSigner {
         // Default salt if none was provided, generated with `openssl rand 32`
-        let salting_key = salting_key.unwrap_or_else(|| {
-            let default = b"\xdf\xcf\xddt\n\xd08a*\xc3\x96\xafj<\x8c\xa7\xaa\x15\xce$\x83ND\xb4\xdf\x98%\xcb\xde\x1f\xf0\x9a";
-            SigningKey::new(&SHA256, default)
-        });
+        let salt = salt.unwrap_or(
+            b"\xdf\xcf\xddt\n\xd08a*\xc3\x96\xafj<\x8c\xa7\xaa\x15\xce$\x83ND\xb4\xdf\x98%\xcb\xde\x1f\xf0\x9a"
+        );
 
         let mut out = Vec::new();
         out.resize(SHA256.block_len, 0);
 
-        extract_and_expand(
-            &salting_key,
+        key_derive(
+            &SHA256,
+            // ~32000 iterations, not quite the 10^6 of Lastpass but also more than 1ms on an i5
+            2 << 16,
+            salt,
             passwd.as_bytes(),
-            b"oxide-auth-token-signer",
             out.as_mut_slice());
         let key = SigningKey::new(&SHA256, out.as_slice());
 


### PR DESCRIPTION
This changes introduces key derivation and a default initial salt to password based token signers.

 - [x] This change has tests
 - [x] This change has documentation
 - [x] Corresponds to issue (#10 )

