### PR TITLE
Check redirect equivalence as url instead of str

### DIFF
--- a/src/code_grant/accesstoken.rs
+++ b/src/code_grant/accesstoken.rs
@@ -123,9 +123,12 @@ pub fn access_token(handler: &mut Endpoint, request: &Request) -> Result<BearerT
     let redirect_uri = request
         .redirect_uri()
         .ok_or(Error::invalid())?;
-    let redirect_uri = redirect_uri.as_ref();
+    let redirect_uri = redirect_uri
+        .as_ref()
+        .parse()
+        .map_err(|_| Error::invalid())?;
 
-    if (saved_params.client_id.as_ref(), saved_params.redirect_uri.as_str()) != (client_id, redirect_uri) {
+    if (saved_params.client_id.as_ref(), &saved_params.redirect_uri) != (client_id, &redirect_uri) {
         return Err(Error::invalid_with(AccessTokenErrorType::InvalidGrant))
     }
 

--- a/src/primitives/registrar.rs
+++ b/src/primitives/registrar.rs
@@ -113,6 +113,10 @@ pub enum RegistrarError {
 /// There are two types of clients, public and confidential. Public clients operate without proof
 /// of identity while confidential clients are granted additional assertions on their communication
 /// with the servers. They might be allowed more freedom as they are harder to impersonate.
+// TODO(from #29): allow verbatim urls. Parsing to Url instigates some normalization making the
+// string representation less predictable. A verbatim url would allow comparing the `redirect_uri`
+// parameter with simple string comparison, a potential speedup.
+// TODO: there is no more an apparent reason for this to be a strictly owning struct.
 #[derive(Clone, Debug)]
 pub struct Client {
     client_id: String,


### PR DESCRIPTION
This fixes an issue where the information lost from parsing the client
provided redirect uri string as an url would lead to unexpected
behaviour when retrieving the access token for the client. Fixed by
performing a full url based comparison.

 - [x] This change has tests (remove for doc only)
 - [ ] This change has documentation
 - [x] Closes: #29 

