### PR TITLE
Cleanup: atomics `const` constructors and `dyn`

### DIFF
--- a/src/code_grant/accesstoken.rs
+++ b/src/code_grant/accesstoken.rs
@@ -46,11 +46,11 @@ pub trait Extension {
     ///
     /// The input data comes from the extension data produced in the handling of the
     /// authorization code request.
-    fn extend(&mut self, request: &Request, data: Extensions) -> std::result::Result<Extensions, ()>;
+    fn extend(&mut self, request: &dyn Request, data: Extensions) -> std::result::Result<Extensions, ()>;
 }
 
 impl Extension for () {
-    fn extend(&mut self, _: &Request, _: Extensions) -> std::result::Result<Extensions, ()> {
+    fn extend(&mut self, _: &dyn Request, _: Extensions) -> std::result::Result<Extensions, ()> {
         Ok(Extensions::new())
     }
 }
@@ -62,22 +62,22 @@ impl Extension for () {
 /// by internally using `primitives`, as it is implemented in the `frontend` module.
 pub trait Endpoint {
     /// Get the client corresponding to some id.
-    fn registrar(&self) -> &Registrar;
+    fn registrar(&self) -> &dyn Registrar;
 
     /// Get the authorizer from which we can recover the authorization.
-    fn authorizer(&mut self) -> &mut Authorizer;
+    fn authorizer(&mut self) -> &mut dyn Authorizer;
 
     /// Return the issuer instance to create the access token.
-    fn issuer(&mut self) -> &mut Issuer;
+    fn issuer(&mut self) -> &mut dyn Issuer;
 
     /// The system of used extension, extending responses.
     ///
     /// It is possible to use `&mut ()`.
-    fn extension(&mut self) -> & mut Extension;
+    fn extension(&mut self) -> & mut dyn Extension;
 }
 
 /// Try to redeem an authorization code.
-pub fn access_token(handler: &mut Endpoint, request: &Request) -> Result<BearerToken> {
+pub fn access_token(handler: &mut dyn Endpoint, request: &dyn Request) -> Result<BearerToken> {
     if !request.valid() {
         return Err(Error::invalid())
     }

--- a/src/code_grant/accesstoken.rs
+++ b/src/code_grant/accesstoken.rs
@@ -255,8 +255,6 @@ impl ErrorDescription {
     /// Convert the error into a json string, viable for being sent over a network with
     /// `application/json` encoding.
     pub fn to_json(self) -> String {
-        use std::iter::IntoIterator;
-        use std::collections::HashMap;
         let asmap = self.error.into_iter()
             .map(|(k, v)| (k.to_string(), v.into_owned()))
             .collect::<HashMap<String, String>>();

--- a/src/code_grant/resource.rs
+++ b/src/code_grant/resource.rs
@@ -101,11 +101,11 @@ pub trait Endpoint {
     fn scopes(&mut self) -> &[Scope];
 
     /// Issuer which provides the tokens used for authorization by the client.
-    fn issuer(&mut self) -> &Issuer;
+    fn issuer(&mut self) -> &dyn Issuer;
 }
 
 /// The result will indicate whether the resource access should be allowed or not.
-pub fn protect(handler: &mut Endpoint, req: &Request) -> Result<Grant> {
+pub fn protect(handler: &mut dyn Endpoint, req: &dyn Request) -> Result<Grant> {
     let authenticate = Authenticate {
         realm: None,
         scope: handler.scopes().get(0).cloned(),

--- a/src/endpoint/accesstoken.rs
+++ b/src/endpoint/accesstoken.rs
@@ -31,7 +31,7 @@ struct WrappedRequest<'a, R: WebRequest + 'a> {
     request: PhantomData<R>,
 
     /// The query in the url.
-    body: Cow<'a, QueryParameter + 'static>,
+    body: Cow<'a, dyn QueryParameter + 'static>,
 
     /// The authorization tuple
     authorization: Option<Authorization>,
@@ -131,19 +131,19 @@ fn token_error<E: Endpoint<R>, R: WebRequest>(endpoint: &mut E, request: &mut R,
 }
 
 impl<E: Endpoint<R>, R: WebRequest> TokenEndpoint for WrappedToken<E, R> {
-    fn registrar(&self) -> &Registrar {
+    fn registrar(&self) -> &dyn Registrar {
         self.inner.registrar().unwrap()
     }
 
-    fn authorizer(&mut self) -> &mut Authorizer {
+    fn authorizer(&mut self) -> &mut dyn Authorizer {
         self.inner.authorizer_mut().unwrap()
     }
 
-    fn issuer(&mut self) -> &mut Issuer {
+    fn issuer(&mut self) -> &mut dyn Issuer {
         self.inner.issuer_mut().unwrap()
     }
 
-    fn extension(&mut self) -> &mut Extension {
+    fn extension(&mut self) -> &mut dyn Extension {
         self.inner.extension()
             .and_then(|ext| ext.access_token())
             .unwrap_or(&mut self.extension_fallback)

--- a/src/endpoint/authorization.rs
+++ b/src/endpoint/authorization.rs
@@ -24,7 +24,7 @@ struct WrappedRequest<'a, R: WebRequest + 'a> {
     request: PhantomData<R>,
 
     /// The query in the url.
-    query: Cow<'a, QueryParameter + 'static>,
+    query: Cow<'a, dyn QueryParameter + 'static>,
 
     /// An error if one occurred.
     error: Option<R::Error>,
@@ -44,7 +44,7 @@ struct AuthorizationPartial<'a, E: 'a, R: 'a> where E: Endpoint<R>, R: WebReques
     inner: AuthorizationPartialInner<'a, E, R>,
 
     /// TODO: offer this in the public api instead of dropping the request.
-    _with_request: Option<Box<FnOnce(R) -> ()>>,
+    _with_request: Option<Box<dyn FnOnce(R) -> ()>>,
 }
 
 /// Result type from processing an authentication request.
@@ -245,21 +245,21 @@ impl<'a, E: Endpoint<R>, R: WebRequest> AuthorizationPending<'a, E, R> {
 }
 
 impl<E: Endpoint<R>, R: WebRequest> WrappedAuthorization<E, R> {
-    fn owner_solicitor(&mut self) -> &mut OwnerSolicitor<R> {
+    fn owner_solicitor(&mut self) -> &mut dyn OwnerSolicitor<R> {
         self.inner.owner_solicitor().unwrap()
     }
 }
 
 impl<E: Endpoint<R>, R: WebRequest> AuthorizationEndpoint for WrappedAuthorization<E, R> {
-    fn registrar(&self) -> &Registrar {
+    fn registrar(&self) -> &dyn Registrar {
         self.inner.registrar().unwrap()
     }
 
-    fn authorizer(&mut self) -> &mut Authorizer {
+    fn authorizer(&mut self) -> &mut dyn Authorizer {
         self.inner.authorizer_mut().unwrap()
     }
 
-    fn extension(&mut self) -> &mut Extension {
+    fn extension(&mut self) -> &mut dyn Extension {
         self.inner.extension()
             .and_then(|ext| ext.authorization())
             .unwrap_or(&mut self.extension_fallback)

--- a/src/endpoint/query.rs
+++ b/src/endpoint/query.rs
@@ -81,8 +81,8 @@ impl NormalizedParameter {
     }
 }
 
-impl Borrow<QueryParameter> for NormalizedParameter {
-    fn borrow(&self) -> &(QueryParameter + 'static) {
+impl Borrow<dyn QueryParameter> for NormalizedParameter {
+    fn borrow(&self) -> &(dyn QueryParameter + 'static) {
         self
     }
 }
@@ -129,7 +129,7 @@ where
    }
 }
 
-impl ToOwned for QueryParameter {
+impl ToOwned for dyn QueryParameter {
     type Owned = NormalizedParameter;
 
     fn to_owned(&self) -> Self::Owned {
@@ -303,12 +303,12 @@ mod test {
     #[allow(unused)]
     #[allow(dead_code)]
     fn test_query_parameter_impls() {
-        let _ = (&HashMap::<String, String>::new()) as &QueryParameter;
-        let _ = (&HashMap::<&'static str, &'static str>::new()) as &QueryParameter;
-        let _ = (&HashMap::<Cow<'static, str>, Cow<'static, str>>::new()) as &QueryParameter;
+        let _ = (&HashMap::<String, String>::new()) as &dyn QueryParameter;
+        let _ = (&HashMap::<&'static str, &'static str>::new()) as &dyn QueryParameter;
+        let _ = (&HashMap::<Cow<'static, str>, Cow<'static, str>>::new()) as &dyn QueryParameter;
 
-        let _ = (&HashMap::<String, Vec<String>>::new()) as &QueryParameter;
-        let _ = (&HashMap::<String, Box<String>>::new()) as &QueryParameter;
-        let _ = (&HashMap::<String, Box<[Cow<'static, str>]>>::new()) as &QueryParameter;
+        let _ = (&HashMap::<String, Vec<String>>::new()) as &dyn QueryParameter;
+        let _ = (&HashMap::<String, Box<String>>::new()) as &dyn QueryParameter;
+        let _ = (&HashMap::<String, Box<[Cow<'static, str>]>>::new()) as &dyn QueryParameter;
     }
 }

--- a/src/endpoint/resource.rs
+++ b/src/endpoint/resource.rs
@@ -133,7 +133,7 @@ impl<'a, E: Endpoint<R> + 'a, R: WebRequest + 'a> ResourceEndpoint for Scoped<'a
         self.endpoint.scopes().unwrap().scopes(self.request)
     }
 
-    fn issuer(&mut self) -> &Issuer {
+    fn issuer(&mut self) -> &dyn Issuer {
         self.endpoint.issuer_mut().unwrap()
     }
 }

--- a/src/endpoint/tests/mod.rs
+++ b/src/endpoint/tests/mod.rs
@@ -79,12 +79,12 @@ impl WebRequest for CraftedRequest {
     type Response = CraftedResponse;
     type Error = CraftedError;
 
-    fn query(&mut self) -> Result<Cow<QueryParameter + 'static>, Self::Error> {
-        self.query.as_ref().map(|hm| Cow::Borrowed(hm as &QueryParameter)).ok_or(CraftedError::Crafted)
+    fn query(&mut self) -> Result<Cow<dyn QueryParameter + 'static>, Self::Error> {
+        self.query.as_ref().map(|hm| Cow::Borrowed(hm as &dyn QueryParameter)).ok_or(CraftedError::Crafted)
     }
 
-    fn urlbody(&mut self) -> Result<Cow<QueryParameter + 'static>, Self::Error> {
-        self.urlbody.as_ref().map(|hm| Cow::Borrowed(hm as &QueryParameter)).ok_or(CraftedError::Crafted)
+    fn urlbody(&mut self) -> Result<Cow<dyn QueryParameter + 'static>, Self::Error> {
+        self.urlbody.as_ref().map(|hm| Cow::Borrowed(hm as &dyn QueryParameter)).ok_or(CraftedError::Crafted)
     }
 
     fn authheader(&mut self) -> Result<Option<Cow<str>>, Self::Error> {

--- a/src/frontends/actix/future_endpoint.rs
+++ b/src/frontends/actix/future_endpoint.rs
@@ -28,7 +28,7 @@ pub fn authorization<R, A, S, W>(
     request: W,
     response: W::Response
 )
-    -> Box<Future<Item=W::Response, Error=W::Error> + 'static>
+    -> Box<dyn Future<Item=W::Response, Error=W::Error> + 'static>
 where
     R: Registrar + 'static,
     A: Authorizer + 'static,
@@ -57,7 +57,7 @@ pub fn access_token<R, A, I, W>(
     request: W,
     response: W::Response
 )
-    -> Box<Future<Item=W::Response, Error=W::Error> + 'static>
+    -> Box<dyn Future<Item=W::Response, Error=W::Error> + 'static>
 where
     R: Registrar + 'static,
     A: Authorizer + 'static,
@@ -86,7 +86,7 @@ pub fn resource<I, W, C>(
     request: W,
     response: W::Response
 )
-    -> Box<Future<Item=Grant, Error=ResourceProtection<W::Response>> + 'static>
+    -> Box<dyn Future<Item=Grant, Error=ResourceProtection<W::Response>> + 'static>
 where
     I: Issuer + 'static,
     C: Scopes<W> + 'static,

--- a/src/frontends/actix/request.rs
+++ b/src/frontends/actix/request.rs
@@ -241,15 +241,15 @@ impl WebRequest for OAuthRequest {
     type Error = OAuthError;
     type Response = OAuthResponse;
 
-     fn query(&mut self) -> Result<Cow<QueryParameter + 'static>, Self::Error> {
+     fn query(&mut self) -> Result<Cow<dyn QueryParameter + 'static>, Self::Error> {
          self.query.as_ref()
-             .map(|query| Cow::Borrowed(query as &QueryParameter))
+             .map(|query| Cow::Borrowed(query as &dyn QueryParameter))
              .map_err(|_| OAuthError::BadRequest)
      }
 
-     fn urlbody(&mut self) -> Result<Cow<QueryParameter + 'static>, Self::Error> {
+     fn urlbody(&mut self) -> Result<Cow<dyn QueryParameter + 'static>, Self::Error> {
          self.body.as_ref()
-             .map(|body| Cow::Borrowed(body as &QueryParameter))
+             .map(|body| Cow::Borrowed(body as &dyn QueryParameter))
              .map_err(|_| OAuthError::BadRequest)
      }
 

--- a/src/frontends/iron.rs
+++ b/src/frontends/iron.rs
@@ -26,13 +26,13 @@ impl<'a, 'b, 'c: 'b> WebRequest for &'a mut Request<'b, 'c> {
     type Response = Response;
     type Error = Error;
 
-    fn query(&mut self) -> Result<Cow<QueryParameter + 'static>, Self::Error> {
+    fn query(&mut self) -> Result<Cow<dyn QueryParameter + 'static>, Self::Error> {
         serde_urlencoded::from_str(self.url.query().unwrap_or(""))
             .map_err(|_| Error::BadRequest)
             .map(Cow::Owned)
     }
 
-    fn urlbody(&mut self) -> Result<Cow<QueryParameter + 'static>, Self::Error> {
+    fn urlbody(&mut self) -> Result<Cow<dyn QueryParameter + 'static>, Self::Error> {
         let content_type = self.headers.get::<headers::ContentType>();
         let formatted = content_type
             .map(|ct| ct == &headers::ContentType::form_url_encoded())

--- a/src/frontends/rocket/mod.rs
+++ b/src/frontends/rocket/mod.rs
@@ -111,17 +111,17 @@ impl<'r> WebRequest for OAuthRequest<'r> {
     type Error = WebError;
     type Response = Response<'r>;
 
-    fn query(&mut self) -> Result<Cow<QueryParameter + 'static>, Self::Error> {
+    fn query(&mut self) -> Result<Cow<dyn QueryParameter + 'static>, Self::Error> {
         match self.query.as_ref() {
-            Ok(query) => Ok(Cow::Borrowed(query as &QueryParameter)),
+            Ok(query) => Ok(Cow::Borrowed(query as &dyn QueryParameter)),
             Err(err) => Err(*err),
         }
     }
 
-    fn urlbody(&mut self) ->  Result<Cow<QueryParameter + 'static>, Self::Error> {
+    fn urlbody(&mut self) ->  Result<Cow<dyn QueryParameter + 'static>, Self::Error> {
         match self.body.as_ref() {
             Ok(None) => Err(WebError::BodyNeeded),
-            Ok(Some(body)) => Ok(Cow::Borrowed(body as &QueryParameter)),
+            Ok(Some(body)) => Ok(Cow::Borrowed(body as &dyn QueryParameter)),
             Err(err) => Err(*err),
         }
     }

--- a/src/frontends/rouille.rs
+++ b/src/frontends/rouille.rs
@@ -30,14 +30,14 @@ impl<'a> WebRequest for &'a Request {
     type Error = WebError;
     type Response = Response;
 
-    fn query(&mut self) -> Result<Cow<QueryParameter + 'static>, Self::Error> {
+    fn query(&mut self) -> Result<Cow<dyn QueryParameter + 'static>, Self::Error> {
         let query = self.raw_query_string();
         let data = serde_urlencoded::from_str(query)
             .map_err(|_| WebError::Encoding)?;
         Ok(Cow::Owned(data))
     }
 
-    fn urlbody(&mut self) -> Result<Cow<QueryParameter + 'static>, Self::Error> {
+    fn urlbody(&mut self) -> Result<Cow<dyn QueryParameter + 'static>, Self::Error> {
         match self.header("Content-Type") {
             None | Some("application/x-www-form-urlencoded") => (),
             _ => return Err(WebError::Encoding),

--- a/src/frontends/simple/extensions/extended.rs
+++ b/src/frontends/simple/extensions/extended.rs
@@ -53,23 +53,23 @@ where
 {
     type Error = Inner::Error;
 
-    fn registrar(&self) -> Option<&Registrar> {
+    fn registrar(&self) -> Option<&dyn Registrar> {
         self.inner.registrar()
     }
 
-    fn authorizer_mut(&mut self) -> Option<&mut Authorizer> {
+    fn authorizer_mut(&mut self) -> Option<&mut dyn Authorizer> {
         self.inner.authorizer_mut()
     }
 
-    fn issuer_mut(&mut self) -> Option<&mut Issuer> {
+    fn issuer_mut(&mut self) -> Option<&mut dyn Issuer> {
         self.inner.issuer_mut()
     }
 
-    fn owner_solicitor(&mut self) -> Option<&mut OwnerSolicitor<Request>> {
+    fn owner_solicitor(&mut self) -> Option<&mut dyn OwnerSolicitor<Request>> {
         self.inner.owner_solicitor()
     }
 
-    fn scopes(&mut self) -> Option<&mut Scopes<Request>> {
+    fn scopes(&mut self) -> Option<&mut dyn Scopes<Request>> {
         self.inner.scopes()
     }
 
@@ -87,7 +87,7 @@ where
         self.inner.web_error(err)
     }
 
-    fn extension(&mut self) -> Option<&mut Extension> {
+    fn extension(&mut self) -> Option<&mut dyn Extension> {
         Some(&mut self.addons)
     }
 }

--- a/src/frontends/simple/extensions/list.rs
+++ b/src/frontends/simple/extensions/list.rs
@@ -12,8 +12,8 @@ use primitives::grant::{Extensions, GrantExtension};
 /// The owning representation of access extensions can be switched out to `Box<_>`, `Rc<_>` or
 /// other types.
 pub struct AddonList {
-    authorization: Vec<Arc<AuthorizationAddon + Send + Sync + 'static>>,
-    access_token: Vec<Arc<AccessTokenAddon + Send + Sync + 'static>>,
+    authorization: Vec<Arc<dyn AuthorizationAddon + Send + Sync + 'static>>,
+    access_token: Vec<Arc<dyn AccessTokenAddon + Send + Sync + 'static>>,
 }
 
 impl AddonList {
@@ -58,17 +58,17 @@ impl Default for AddonList {
 }
 
 impl Extension for AddonList {
-    fn authorization(&mut self) -> Option<&mut AuthorizationExtension> {
+    fn authorization(&mut self) -> Option<&mut dyn AuthorizationExtension> {
         Some(self)
     }
 
-    fn access_token(&mut self) -> Option<&mut AccessTokenExtension> {
+    fn access_token(&mut self) -> Option<&mut dyn AccessTokenExtension> {
         Some(self)
     }
 }
 
 impl AccessTokenExtension for AddonList {
-    fn extend(&mut self, request: &Request, mut data: Extensions) -> std::result::Result<Extensions, ()> {
+    fn extend(&mut self, request: &dyn Request, mut data: Extensions) -> std::result::Result<Extensions, ()> {
         let mut result_data = Extensions::new();
 
         for ext in self.access_token.iter() {
@@ -87,7 +87,7 @@ impl AccessTokenExtension for AddonList {
 }
 
 impl AuthorizationExtension for AddonList {
-    fn extend(&mut self, request: &AuthRequest) -> Result<Extensions, ()> {
+    fn extend(&mut self, request: &dyn AuthRequest) -> Result<Extensions, ()> {
         let mut result_data = Extensions::new();
 
         for ext in self.authorization.iter() {

--- a/src/frontends/simple/extensions/mod.rs
+++ b/src/frontends/simple/extensions/mod.rs
@@ -42,7 +42,7 @@ pub trait AuthorizationAddon: GrantExtension {
     /// encoded form by returning `Ok(extension_data)` while errors can be signaled via `Err(())`.
     /// Extensions can also store their pure existance by initializing the extension struct without
     /// data. Specifically, the data can be used in a corresponding `AccessTokenExtension`.
-    fn execute(&self, request: &AuthorizationRequest) -> AddonResult;
+    fn execute(&self, request: &dyn AuthorizationRequest) -> AddonResult;
 }
 
 /// An extension reacting to an access token request with a provided access token.
@@ -52,11 +52,11 @@ pub trait AccessTokenAddon: GrantExtension {
     /// The semantics are equivalent to that of `CodeExtension` except that any data which was
     /// returned as a response to the authorization code request is provided as an additional
     /// parameter.
-    fn execute(&self, request: &AccessTokenRequest, code_data: Option<Value>) -> AddonResult;
+    fn execute(&self, request: &dyn AccessTokenRequest, code_data: Option<Value>) -> AddonResult;
 }
 
 impl<'a, T: AuthorizationAddon + ?Sized> AuthorizationAddon for &'a T {
-    fn execute(&self, request: &AuthorizationRequest) -> AddonResult {
+    fn execute(&self, request: &dyn AuthorizationRequest) -> AddonResult {
         (**self).execute(request)
     }
 }
@@ -64,32 +64,32 @@ impl<'a, T: AuthorizationAddon + ?Sized> AuthorizationAddon for &'a T {
 impl<'a, T: AuthorizationAddon + ?Sized> AuthorizationAddon for Cow<'a, T> 
     where T: Clone + ToOwned
 {
-    fn execute(&self, request: &AuthorizationRequest) -> AddonResult {
+    fn execute(&self, request: &dyn AuthorizationRequest) -> AddonResult {
         self.as_ref().execute(request)
     }
 }
 
 impl<T: AuthorizationAddon + ?Sized> AuthorizationAddon for Box<T> {
-    fn execute(&self, request: &AuthorizationRequest) -> AddonResult {
+    fn execute(&self, request: &dyn AuthorizationRequest) -> AddonResult {
         (**self).execute(request)
     }
 }
 
 impl<T: AuthorizationAddon + ?Sized> AuthorizationAddon for Arc<T> {
-    fn execute(&self, request: &AuthorizationRequest) -> AddonResult {
+    fn execute(&self, request: &dyn AuthorizationRequest) -> AddonResult {
         (**self).execute(request)
     }
 }
 
 impl<T: AuthorizationAddon + ?Sized> AuthorizationAddon for Rc<T> {
-    fn execute(&self, request: &AuthorizationRequest) -> AddonResult {
+    fn execute(&self, request: &dyn AuthorizationRequest) -> AddonResult {
         (**self).execute(request)
     }
 }
 
 
 impl<'a, T: AccessTokenAddon + ?Sized> AccessTokenAddon for &'a T {
-    fn execute(&self, request: &AccessTokenRequest, data: Option<Value>) -> AddonResult {
+    fn execute(&self, request: &dyn AccessTokenRequest, data: Option<Value>) -> AddonResult {
         (**self).execute(request, data)
     }
 }
@@ -97,25 +97,25 @@ impl<'a, T: AccessTokenAddon + ?Sized> AccessTokenAddon for &'a T {
 impl<'a, T: AccessTokenAddon + ?Sized> AccessTokenAddon for Cow<'a, T> 
     where T: Clone + ToOwned
 {
-    fn execute(&self, request: &AccessTokenRequest, data: Option<Value>) -> AddonResult {
+    fn execute(&self, request: &dyn AccessTokenRequest, data: Option<Value>) -> AddonResult {
         self.as_ref().execute(request, data)
     }
 }
 
 impl<T: AccessTokenAddon + ?Sized> AccessTokenAddon for Box<T> {
-    fn execute(&self, request: &AccessTokenRequest, data: Option<Value>) -> AddonResult {
+    fn execute(&self, request: &dyn AccessTokenRequest, data: Option<Value>) -> AddonResult {
         (**self).execute(request, data)
     }
 }
 
 impl<T: AccessTokenAddon + ?Sized> AccessTokenAddon for Arc<T> {
-    fn execute(&self, request: &AccessTokenRequest, data: Option<Value>) -> AddonResult {
+    fn execute(&self, request: &dyn AccessTokenRequest, data: Option<Value>) -> AddonResult {
         (**self).execute(request, data)
     }
 }
 
 impl<T: AccessTokenAddon + ?Sized> AccessTokenAddon for Rc<T> {
-    fn execute(&self, request: &AccessTokenRequest, data: Option<Value>) -> AddonResult {
+    fn execute(&self, request: &dyn AccessTokenRequest, data: Option<Value>) -> AddonResult {
         (**self).execute(request, data)
     }
 }

--- a/src/frontends/simple/extensions/pkce.rs
+++ b/src/frontends/simple/extensions/pkce.rs
@@ -4,7 +4,7 @@ use super::{AddonResult, Value};
 pub use code_grant::extensions::Pkce;
 
 impl AuthorizationAddon for Pkce {
-    fn execute(&self, request: &AuthorizationRequest) -> AddonResult {
+    fn execute(&self, request: &dyn AuthorizationRequest) -> AddonResult {
         let method = request.extension("code_challenge_method");
         let challenge = request.extension("code_challenge");
 
@@ -19,7 +19,7 @@ impl AuthorizationAddon for Pkce {
 }
 
 impl AccessTokenAddon for Pkce {
-    fn execute(&self, request: &AccessTokenRequest, data: Option<Value>) -> AddonResult {
+    fn execute(&self, request: &dyn AccessTokenRequest, data: Option<Value>) -> AddonResult {
         let verifier = request.extension("code_verifier");
 
         match self.verify(data, verifier) {

--- a/src/frontends/simple/request.rs
+++ b/src/frontends/simple/request.rs
@@ -114,11 +114,11 @@ impl WebRequest for Request {
     type Error = NoError;
     type Response = Response;
 
-    fn query(&mut self) -> Result<Cow<QueryParameter + 'static>, Self::Error> {
+    fn query(&mut self) -> Result<Cow<dyn QueryParameter + 'static>, Self::Error> {
         Ok(Cow::Borrowed(&self.query))
     }
 
-    fn urlbody(&mut self) -> Result<Cow<QueryParameter + 'static>, Self::Error> {
+    fn urlbody(&mut self) -> Result<Cow<dyn QueryParameter + 'static>, Self::Error> {
         Ok(Cow::Borrowed(&self.urlbody))
     }
 
@@ -193,11 +193,11 @@ impl<W: WebRequest, F, T> WebRequest for MapErr<W, F, T> where F: FnMut(W::Error
     type Error = T;
     type Response = MapErr<W::Response, F, T>;
 
-    fn query(&mut self) -> Result<Cow<QueryParameter + 'static>, Self::Error> {
+    fn query(&mut self) -> Result<Cow<dyn QueryParameter + 'static>, Self::Error> {
         self.0.query().map_err(&mut self.1)
     }
 
-    fn urlbody(&mut self) -> Result<Cow<QueryParameter + 'static>, Self::Error> {
+    fn urlbody(&mut self) -> Result<Cow<dyn QueryParameter + 'static>, Self::Error> {
         self.0.urlbody().map_err(&mut self.1)
     }
 

--- a/src/primitives/authorizer.rs
+++ b/src/primitives/authorizer.rs
@@ -29,7 +29,7 @@ pub trait Authorizer {
 /// This authorizer saves a mapping of generated strings to their associated grants. The generator
 /// is itself trait based and can be chosen during construction. It is assumed to not be possible
 /// for two different grants to generate the same token in the issuer.
-pub struct AuthMap<I: TagGrant=Box<TagGrant + Send + Sync + 'static>> {
+pub struct AuthMap<I: TagGrant=Box<dyn TagGrant + Send + Sync + 'static>> {
     tagger: I,
     usage: u64,
     tokens: HashMap<String, Grant>
@@ -121,7 +121,7 @@ pub mod tests {
     /// Tests some invariants that should be upheld by all authorizers.
     ///
     /// Custom implementations may want to import and use this in their own tests.
-    pub fn simple_test_suite(authorizer: &mut Authorizer) {
+    pub fn simple_test_suite(authorizer: &mut dyn Authorizer) {
         let grant = Grant {
             owner_id: "Owner".to_string(),
             client_id: "Client".to_string(),

--- a/src/primitives/grant.rs
+++ b/src/primitives/grant.rs
@@ -114,7 +114,7 @@ impl Extensions {
     }
 
     /// Set the stored content for a `GrantExtension` instance.
-    pub fn set(&mut self, extension: &GrantExtension, content: Value) {
+    pub fn set(&mut self, extension: &dyn GrantExtension, content: Value) {
         self.extensions.insert(extension.identifier().to_string(), content);
     }
 
@@ -127,7 +127,7 @@ impl Extensions {
     ///
     /// This removes the data from the store to avoid possible mixups and to allow a copyless
     /// retrieval of bigger data strings.
-    pub fn remove(&mut self, extension: &GrantExtension) -> Option<Value> {
+    pub fn remove(&mut self, extension: &dyn GrantExtension) -> Option<Value> {
         self.extensions.remove(extension.identifier())
     }
 

--- a/src/primitives/issuer.rs
+++ b/src/primitives/issuer.rs
@@ -51,7 +51,7 @@ pub struct IssuedToken {
 /// The generator is itself trait based and can be chosen during construction. It is assumed to not
 /// be possible (or at least very unlikely during their overlapping lifetime) for two different
 /// grants to generate the same token in the grant tagger.
-pub struct TokenMap<G: TagGrant=Box<TagGrant + Send + Sync + 'static>> {
+pub struct TokenMap<G: TagGrant=Box<dyn TagGrant + Send + Sync + 'static>> {
     duration: Option<Duration>,
     generator: G,
     usage: u64,
@@ -320,7 +320,7 @@ pub mod tests {
     /// Generation of a valid refresh token is not tested against.
     ///
     /// Custom implementations may want to import and use this in their own tests.
-    pub fn simple_test_suite(issuer: &mut Issuer) {
+    pub fn simple_test_suite(issuer: &mut dyn Issuer) {
         let request = Grant {
             client_id: "Client".to_string(),
             owner_id: "Owner".to_string(),

--- a/src/primitives/issuer.rs
+++ b/src/primitives/issuer.rs
@@ -5,7 +5,7 @@
 //! while the other uses cryptographic signing.
 use std::collections::HashMap;
 use std::sync::{MutexGuard, RwLockWriteGuard};
-use std::sync::atomic::{ATOMIC_USIZE_INIT, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use chrono::{Duration, Utc};
 
@@ -159,7 +159,7 @@ impl TokenSigner {
         TokenSigner { 
             duration: None,
             signer: secret.into(),
-            counter: ATOMIC_USIZE_INIT,
+            counter: AtomicUsize::new(0),
         }
     }
 


### PR DESCRIPTION
Usage of `ATOMIC_*_INIT` is deprecated since the constructors are now properly
`const` for integer atomics. So use them. Also prepares stricter code style and the
eventual edition switch by fixing all usages of dynamic trait objects.

