### PR TITLE
Fix pbkdf2 strength check

### DIFF
--- a/src/primitives/registrar.rs
+++ b/src/primitives/registrar.rs
@@ -317,7 +317,7 @@ impl Pbkdf2 {
     ///
     /// This function will panic when the `strength` is larger or equal to `32`.
     pub fn set_relative_strength(&mut self, strength: u8) {
-        assert!(strength < 64, "Strength value out of range (0-31): {}", strength);
+        assert!(strength < 32, "Strength value out of range (0-31): {}", strength);
         self.iterations = 1u32 << strength as u32;
     }
 


### PR DESCRIPTION
The iteration count is a 32-bit integer so that the strength can be at
most 31. The left shift needs to check its argument and properly as
stated in the documentation. Note that this is not undefined behaviour
but could silently lead lower strength than desired.

 - [ ] This change has tests (remove for doc only)
 - [x] This change has documentation
