### PR TITLE
Apply many Clippy lints

### DIFF
--- a/src/code_grant/accesstoken.rs
+++ b/src/code_grant/accesstoken.rs
@@ -108,7 +108,7 @@ pub fn access_token(handler: &mut dyn Endpoint, request: &dyn Request) -> Result
 
     let code = request
         .code()
-        .ok_or(Error::invalid())?;
+        .ok_or_else(Error::invalid)?;
     let code = code.as_ref();
 
     let saved_params = match handler.authorizer().extract(code) {
@@ -122,7 +122,7 @@ pub fn access_token(handler: &mut dyn Endpoint, request: &dyn Request) -> Result
 
     let redirect_uri = request
         .redirect_uri()
-        .ok_or(Error::invalid())?;
+        .ok_or_else(Error::invalid)?;
     let redirect_uri = redirect_uri
         .as_ref()
         .parse()

--- a/src/code_grant/authorization.rs
+++ b/src/code_grant/authorization.rs
@@ -152,7 +152,7 @@ pub fn authorization_code(handler: &mut dyn Endpoint, request: &dyn Request)
 
     Ok(Pending {
         pre_grant,
-        state: state.map(|cow| cow.into_owned()),
+        state: state.map(Cow::into_owned),
         extensions: grant_extension,
     })
 }
@@ -238,7 +238,7 @@ impl ErrorUrl {
     fn new<S>(mut url: Url, state: Option<S>, error: AuthorizationError) -> ErrorUrl where S: AsRef<str> {
         url.query_pairs_mut()
             .extend_pairs(state.as_ref().map(|st| ("state", st.as_ref())));
-        ErrorUrl{ base_uri: url, error: error }
+        ErrorUrl{ base_uri: url, error }
     }
 
     /// Get a handle to the description the client will receive.

--- a/src/code_grant/error.rs
+++ b/src/code_grant/error.rs
@@ -223,8 +223,8 @@ impl IntoIterator for AuthorizationError {
     type IntoIter = IntoIter<(&'static str, Cow<'static, str>)>;
     fn into_iter(self) -> Self::IntoIter {
         let mut vec = vec![("error", Cow::Borrowed(self.error.description()))];
-        self.description.map(|d| vec.push(("description", d)));
-        self.uri.map(|uri| vec.push(("uri", uri)));
+        vec.extend(self.description.map(|d| ("description", d)));
+        vec.extend(self.uri.map(|uri| ("uri", uri)));
         vec.into_iter()
     }
 }
@@ -235,8 +235,8 @@ impl IntoIterator for AccessTokenError {
     type IntoIter = IntoIter<(&'static str, Cow<'static, str>)>;
     fn into_iter(self) -> Self::IntoIter {
         let mut vec = vec![("error", Cow::Borrowed(self.error.description()))];
-        self.description.map(|d| vec.push(("description", d)));
-        self.uri.map(|uri| vec.push(("uri", uri)));
+        vec.extend(self.description.map(|d| ("description", d)));
+        vec.extend(self.uri.map(|uri| ("uri", uri)));
         vec.into_iter()
     }
 }

--- a/src/code_grant/extensions/pkce.rs
+++ b/src/code_grant/extensions/pkce.rs
@@ -130,7 +130,7 @@ fn b64encode(data: &[u8]) -> String {
 
 impl Method {
     fn from_parameter(method: Cow<str>, challenge: Cow<str>) -> Result<Self, ()> {
-        match &*method {
+        match method.as_ref() {
             "plain" => Ok(Method::Plain(challenge.into_owned())),
             "S256" => Ok(Method::Sha256(challenge.into_owned())),
             _ => Err(()),
@@ -165,10 +165,10 @@ impl Method {
 
     fn verify(&self, verifier: &str) -> Result<(), ()> {
         match self {
-            &Method::Plain(ref encoded) =>
+            Method::Plain(encoded) =>
                 verify_slices_are_equal(encoded.as_bytes(), verifier.as_bytes())
                     .map_err(|_| ()),
-            &Method::Sha256(ref encoded) => {
+            Method::Sha256(encoded) => {
                 let digest = digest(&SHA256, verifier.as_bytes());
                 let b64digest = b64encode(digest.as_ref());
                 verify_slices_are_equal(encoded.as_bytes(), b64digest.as_bytes())

--- a/src/code_grant/resource.rs
+++ b/src/code_grant/resource.rs
@@ -71,7 +71,7 @@ pub enum Error {
     PrimitiveError,
 }
 
-const BEARER_START: &'static str = "Bearer ";
+const BEARER_START: &str = "Bearer ";
 
 type Result<T> = std::result::Result<T, Error>;
 
@@ -163,7 +163,7 @@ pub fn protect(handler: &mut dyn Endpoint, req: &dyn Request) -> Result<Grant> {
         });
     }
 
-    return Ok(grant)
+    Ok(grant)
 }
 
 impl ErrorCode {

--- a/src/endpoint/accesstoken.rs
+++ b/src/endpoint/accesstoken.rs
@@ -145,7 +145,7 @@ impl<E: Endpoint<R>, R: WebRequest> TokenEndpoint for WrappedToken<E, R> {
 
     fn extension(&mut self) -> &mut dyn Extension {
         self.inner.extension()
-            .and_then(|ext| ext.access_token())
+            .and_then(super::Extension::access_token)
             .unwrap_or(&mut self.extension_fallback)
     }
 }

--- a/src/endpoint/accesstoken.rs
+++ b/src/endpoint/accesstoken.rs
@@ -37,7 +37,14 @@ struct WrappedRequest<'a, R: WebRequest + 'a> {
     authorization: Option<Authorization>,
 
     /// An error if one occurred.
-    error: Option<Option<R::Error>>,
+    error: Option<FailParse<R::Error>>,
+}
+
+struct Invalid;
+
+enum FailParse<E> {
+    Invalid,
+    Err(E),
 }
 
 struct Authorization(String, Vec<u8>);
@@ -156,23 +163,23 @@ impl<'a, R: WebRequest + 'a> WrappedRequest<'a, R> {
             .unwrap_or_else(Self::from_err)
     }
 
-    fn new_or_fail(request: &'a mut R) -> Result<Self, Option<R::Error>> {
+    fn new_or_fail(request: &'a mut R) -> Result<Self, FailParse<R::Error>> {
         // If there is a header, it must parse correctly.
         let authorization = match request.authheader() {
-            Err(err) => return Err(Some(err)),
+            Err(err) => return Err(FailParse::Err(err)),
             Ok(Some(header)) => Self::parse_header(header).map(Some)?,
             Ok(None) => None,
         };
 
         Ok(WrappedRequest {
             request: PhantomData,
-            body: request.urlbody()?,
+            body: request.urlbody().map_err(FailParse::Err)?,
             authorization,
             error: None,
         })
     }
 
-    fn from_err(err: Option<R::Error>) -> Self {
+    fn from_err(err: FailParse<R::Error>) -> Self {
         WrappedRequest {
             request: PhantomData,
             body: Cow::Owned(Default::default()),
@@ -181,29 +188,29 @@ impl<'a, R: WebRequest + 'a> WrappedRequest<'a, R> {
         }
     }
 
-    fn parse_header(header: Cow<str>) -> Result<Authorization, Option<R::Error>> {
+    fn parse_header(header: Cow<str>) -> Result<Authorization, Invalid> {
         let authorization = {
             if !header.starts_with("Basic ") {
-                return Err(None)
+                return Err(Invalid)
             }
 
             let combined = match base64::decode(&header[6..]) {
-                Err(_) => return Err(None),
+                Err(_) => return Err(Invalid),
                 Ok(vec) => vec,
             };
 
             let mut split = combined.splitn(2, |&c| c == b':');
             let client_bin = match split.next() {
-                None => return Err(None),
+                None => return Err(Invalid),
                 Some(client) => client,
             };
             let passwd = match split.next() {
-                None => return Err(None),
+                None => return Err(Invalid),
                 Some(passwd64) => passwd64,
             };
 
             let client = match from_utf8(client_bin) {
-                Err(_) => return Err(None),
+                Err(_) => return Err(Invalid),
                 Ok(client) => client,
             };
 
@@ -242,5 +249,11 @@ impl<'a, R: WebRequest> TokenRequest for WrappedRequest<'a, R> {
 
     fn extension(&self, key: &str) -> Option<Cow<str>> {
         self.body.unique_value(key)
+    }
+}
+
+impl<E> From<Invalid> for FailParse<E> {
+    fn from(_: Invalid) -> Self {
+        FailParse::Invalid
     }
 }

--- a/src/endpoint/authorization.rs
+++ b/src/endpoint/authorization.rs
@@ -261,7 +261,7 @@ impl<E: Endpoint<R>, R: WebRequest> AuthorizationEndpoint for WrappedAuthorizati
 
     fn extension(&mut self) -> &mut dyn Extension {
         self.inner.extension()
-            .and_then(|ext| ext.authorization())
+            .and_then(super::Extension::authorization)
             .unwrap_or(&mut self.extension_fallback)
     }
 }

--- a/src/endpoint/resource.rs
+++ b/src/endpoint/resource.rs
@@ -144,6 +144,6 @@ impl<R: WebRequest> ResourceRequest for WrappedRequest<R> {
     }
 
     fn token(&self) -> Option<Cow<str>> {
-        self.authorization.as_ref().map(|cow| cow.as_ref()).map(Cow::Borrowed)
+        self.authorization.as_ref().map(String::as_str).map(Cow::Borrowed)
     }
 }

--- a/src/endpoint/resource.rs
+++ b/src/endpoint/resource.rs
@@ -24,7 +24,9 @@ struct WrappedRequest<R: WebRequest> {
     authorization: Option<String>,
 
     /// An error if one occurred.
-    error: Option<Option<R::Error>>,
+    ///
+    /// Actual parsing of the authorization header is done in the lower level.
+    error: Option<R::Error>,
 }
 
 struct Scoped<'a, E: 'a, R: 'a> {
@@ -123,7 +125,7 @@ impl<R: WebRequest> WrappedRequest<R> {
         WrappedRequest {
             request: PhantomData,
             authorization: None,
-            error: Some(Some(error)),
+            error: Some(error),
         }
     }
 }

--- a/src/frontends/actix/request.rs
+++ b/src/frontends/actix/request.rs
@@ -255,9 +255,9 @@ impl WebRequest for OAuthRequest {
 
      fn authheader(&mut self) -> Result<Option<Cow<str>>, Self::Error>{
          match &self.auth {
-             &Ok(Some(ref string)) => Ok(Some(Cow::Borrowed(string))),
-             &Ok(None) => Ok(None),
-             &Err(_) => Err(OAuthError::BadRequest)
+             Ok(Some(string)) => Ok(Some(Cow::Borrowed(string))),
+             Ok(None) => Ok(None),
+             Err(_) => Err(OAuthError::BadRequest)
          }
      }
 }

--- a/src/frontends/simple/extensions/list.rs
+++ b/src/frontends/simple/extensions/list.rs
@@ -112,7 +112,7 @@ impl fmt::Debug for AddonList {
         impl<'a, T: GrantExtension> fmt::Debug for ExtIter<'a, T> {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_list()
-                    .entries(self.0.clone().map(|t| t.identifier()))
+                    .entries(self.0.clone().map(T::identifier))
                     .finish()
             }
         }

--- a/src/primitives/generator.rs
+++ b/src/primitives/generator.rs
@@ -127,7 +127,7 @@ impl Assertion {
 
     /// Construct an assertion instance whose tokens are only valid for the program execution.
     pub fn ephermal() -> Assertion {
-        SigningKey::generate(&SHA256, &mut SystemRandom::new()).unwrap().into()
+        SigningKey::generate(&SHA256, &SystemRandom::new()).unwrap().into()
     }
 
     /// Get a reference to generator for the given tag.
@@ -315,7 +315,7 @@ mod time_serde {
 impl SerdeAssertionGrant {
     fn try_from(grant: &Grant) -> Result<Self, ()> {
         let mut public_extensions: HashMap<String, Option<String>> = HashMap::new();
-        if let Some(_) = grant.extensions.iter_private().next() {
+        if grant.extensions.iter_private().any(|_| true) {
             return Err(())
         };
         for (name, content) in grant.extensions.iter_public() {
@@ -326,7 +326,7 @@ impl SerdeAssertionGrant {
             client_id: grant.client_id.clone(),
             scope: grant.scope.clone(),
             redirect_uri: grant.redirect_uri.clone(),
-            until: grant.until.clone(),
+            until: grant.until,
             public_extensions,
         })
     }
@@ -342,7 +342,7 @@ impl SerdeAssertionGrant {
             scope: self.scope,
             redirect_uri: self.redirect_uri,
             until: self.until,
-            extensions: extensions,
+            extensions,
         }
     }
 }

--- a/src/primitives/grant.rs
+++ b/src/primitives/grant.rs
@@ -40,7 +40,7 @@ pub enum Value {
 ///
 /// This also serves as a clean interface for both frontend and backend to reliably and
 /// conveniently manipulate or query the stored data sets.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
 pub struct Extensions {
     extensions: HashMap<String, Value>,
 }
@@ -108,9 +108,7 @@ impl Value {
 impl Extensions {
     /// Create a new extension store.
     pub fn new() -> Extensions {
-        Extensions {
-            extensions: HashMap::new(),
-        }
+        Extensions::default()
     }
 
     /// Set the stored content for a `GrantExtension` instance.
@@ -158,8 +156,8 @@ impl<'a> Iterator for PublicExtensions<'a> {
         loop {
             match self.0.next() {
                 None => return None,
-                Some((key, &Value::Public(ref content)))
-                    => return Some((key, content.as_ref().map(|st| st.as_str()))),
+                Some((key, Value::Public(content)))
+                    => return Some((key, content.as_ref().map(String::as_str))),
                 _ => (),
             }
         }
@@ -173,8 +171,8 @@ impl<'a> Iterator for PrivateExtensions<'a> {
         loop {
             match self.0.next() {
                 None => return None,
-                Some((key, &Value::Private(ref content)))
-                    => return Some((key, content.as_ref().map(|st| st.as_str()))),
+                Some((key, Value::Private(content)))
+                    => return Some((key, content.as_ref().map(String::as_str))),
                 _ => (),
             }
         }

--- a/src/primitives/issuer.rs
+++ b/src/primitives/issuer.rs
@@ -123,7 +123,7 @@ impl<G: TagGrant> Issuer for TokenMap<G> {
             (token, refresh)
         };
 
-        let until = grant.until.clone();
+        let until = grant.until;
         self.access.insert(token.clone(), grant.clone());
         self.refresh.insert(refresh.clone(), grant);
         self.usage = next_usage;

--- a/src/primitives/scope.rs
+++ b/src/primitives/scope.rs
@@ -96,15 +96,15 @@ impl str::FromStr for Scope {
         if let Some(ch) = string.chars().find(|&ch| Scope::invalid_scope_char(ch)) {
             return Err(ParseScopeErr::InvalidCharacter(ch))
         }
-        let tokens = string.split(' ').filter(|s| s.len() > 0);
-        Ok(Scope{ tokens: tokens.map(|r| r.to_string()).collect() })
+        let tokens = string.split(' ').filter(|s| !s.is_empty());
+        Ok(Scope{ tokens: tokens.map(str::to_string).collect() })
     }
 }
 
 impl fmt::Display for ParseScopeErr {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         match self {
-            &ParseScopeErr::InvalidCharacter(ref chr)
+            ParseScopeErr::InvalidCharacter(chr)
                 => write!(fmt, "Encountered invalid character in scope: {}", chr)
         }
     }
@@ -121,8 +121,8 @@ impl fmt::Debug for Scope {
 impl fmt::Display for Scope {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         let output = self.tokens.iter()
-            .map(|s| s.as_str())
-            .collect::<Vec<&str>>()
+            .map(String::as_str)
+            .collect::<Vec<_>>()
             .join(" ");
         fmt.write_str(&output)
     }


### PR DESCRIPTION
Intended to improve the readability of the code which it does, at times. 
Running clippy also exposed a bunch of naming problems which are
dealt with separately under #35 as they would be a breaking change.
