### PR TITLE
Soft fixes for broken interfaces

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -22,6 +22,7 @@ nightly_task:
   cargo_cache:
     folder: $CARGO_HOME/registry
     fingerprint_script: cat Cargo.lock
+  pre_script: cargo --version
   build_script: cargo build --no-default-features --features "rocket-frontend"
   test_script: cargo test --no-default-features --features "rocket-frontend"
   before_cache_script: rm -rf $CARGO_HOME/registry/index

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,6 +160,15 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "atty"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "autocfg"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -746,17 +755,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "isatty"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.49 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "itoa"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1097,7 +1095,7 @@ dependencies = [
  "reqwest 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.13.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rmp-serde 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocket 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rouille 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "router 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.83 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1448,40 +1446,40 @@ dependencies = [
 
 [[package]]
 name = "rocket"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "isatty 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pear 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocket_codegen 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocket_http 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket_codegen 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket_http 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "state 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "yansi 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rocket_codegen"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "devise 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocket_http 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket_http 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "yansi 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rocket_http"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cookie 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2183,6 +2181,11 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "version_check"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2278,6 +2281,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71"
 "checksum ascii 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)" = "97be891acc47ca214468e09425d02cef3af2c94d0d82081cd02061f996802f14"
 "checksum askama_escape 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "719b48039ffac1564f67d70162109ba9341125cee0096a540e478355b3c724a7"
+"checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 "checksum autocfg 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4e5f34df7a019573fb8bdc7e24a2bfebe51a2a1d6bfdbaeccedb3c41fc574727"
 "checksum backtrace 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "b5b493b66e03090ebc4343eb02f94ff944e0cbc9ac6571491d170ba026741eb5"
 "checksum backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "797c830ac25ccc92a7f8a7b9862bde440715531514594a6154e3d4a54dd769b6"
@@ -2343,7 +2347,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum ipconfig 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "08f7eadeaf4b52700de180d147c4805f199854600b36faa963d91114827b2ffc"
 "checksum iron 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d8e17268922834707e1c29e8badbf9c712c9c43378e1b6a3388946baff10be2"
-"checksum isatty 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e31a8281fc93ec9693494da65fbf28c0c2aa60a2eaec25dc58e2f31952e95edc"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
@@ -2418,9 +2421,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum ring 0.13.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2c4db68a2e35f3497146b7e4563df7d4773a2433230c5e4b448328e31740458a"
 "checksum rmp 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a3d45d7afc9b132b34a2479648863aa95c5c88e98b32285326a6ebadc80ec5c9"
 "checksum rmp-serde 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)" = "011e1d58446e9fa3af7cdc1fb91295b10621d3ac4cb3a85cc86385ee9ca50cd3"
-"checksum rocket 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "242154377a85c2a9e036fc31ffc8c200b9e1f22a196e47baa3b57716606ca89d"
-"checksum rocket_codegen 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7d907d6d458c859651c1cf4c8fa99b77685082bde0561db6a4600b365058f710"
-"checksum rocket_http 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba9d4f2ce5bba6e1b6d3100493bbad63879e99bbf6b4365d61e6f781daab324d"
+"checksum rocket 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "42c1e9deb3ef4fa430d307bfccd4231434b707ca1328fae339c43ad1201cc6f7"
+"checksum rocket_codegen 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "79aa1366f9b2eccddc05971e17c5de7bb75a5431eb12c2b5c66545fd348647f4"
+"checksum rocket_http 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b1391457ee4e80b40d4b57fa5765c0f2836b20d73bcbee4e3f35d93cf3b80817"
 "checksum rouille 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "112568052ec17fa26c6c11c40acbb30d3ad244bf3d6da0be181f5e7e42e5004f"
 "checksum route-recognizer 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3255338088df8146ba63d60a9b8e3556f1146ce2973bc05a75181a42ce2256"
 "checksum router 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dc63b6f3b8895b0d04e816b2b1aa58fdba2d5acca3cbb8f0ab8e017347d57397"
@@ -2495,6 +2498,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum uuid 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dab5c5526c5caa3d106653401a267fed923e7046f35895ffcb5ca42db64942e6"
 "checksum vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "def296d3eb3b12371b2c7d0e83bfe1403e4db2d7a0bba324a12b21c4ee13143d"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
+"checksum version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum want 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "797464475f30ddb8830cc529aaaae648d581f99e2036a928877dfde027ddf6b3"
 "checksum widestring 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7157704c2e12e3d2189c507b7482c52820a16dfa4465ba91add92f266667cadb"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ actix-web = { version = "0.7.17", optional = true }
 mime = { version = "0.3.13", optional = true }
 futures = { version = "0.1", optional = true }
 iron = { version = "0.6", optional = true }
-rocket = { version = "0.4.0", optional = true }
+rocket = { version = "0.4.2", optional = true }
 rouille = { version = "3.0", optional = true }
 router = { version = "0.6", optional = true }
 serde_urlencoded = { version = "0.5.1", optional = true }

--- a/src/primitives/generator.rs
+++ b/src/primitives/generator.rs
@@ -126,7 +126,14 @@ impl Assertion {
     }
 
     /// Construct an assertion instance whose tokens are only valid for the program execution.
+    #[deprecated = "Use the correctly named `ephemeral` instead."]
+    #[doc(hidden)]
     pub fn ephermal() -> Assertion {
+        Self::ephemeral()
+    }
+
+    /// Construct an assertion instance whose tokens are only valid for the program execution.
+    pub fn ephemeral() -> Self {
         SigningKey::generate(&SHA256, &SystemRandom::new()).unwrap().into()
     }
 

--- a/src/primitives/generator.rs
+++ b/src/primitives/generator.rs
@@ -322,12 +322,15 @@ mod time_serde {
 impl SerdeAssertionGrant {
     fn try_from(grant: &Grant) -> Result<Self, ()> {
         let mut public_extensions: HashMap<String, Option<String>> = HashMap::new();
-        if grant.extensions.iter_private().any(|_| true) {
+
+        if grant.extensions.private().any(|_| true) {
             return Err(())
-        };
-        for (name, content) in grant.extensions.iter_public() {
+        }
+
+        for (name, content) in grant.extensions.public() {
             public_extensions.insert(name.to_string(), content.map(str::to_string));
         }
+
         Ok(SerdeAssertionGrant {
             owner_id: grant.owner_id.clone(),
             client_id: grant.client_id.clone(),

--- a/src/primitives/grant.rs
+++ b/src/primitives/grant.rs
@@ -118,7 +118,7 @@ impl Extensions {
 
     /// Set content for an extension without a corresponding instance.
     pub fn set_raw(&mut self, identifier: String, content: Value) {
-        self.extensions.insert(identifier.to_string(), content);
+        self.extensions.insert(identifier, content);
     }
 
     /// Retrieve the stored data of an instance.
@@ -130,18 +130,46 @@ impl Extensions {
     }
 
     /// Iterate of the public extensions whose presence and content is not secret.
+    #[deprecated = "Use the simpler `public` instead."]
     pub fn iter_public(&self) -> PublicExtensions {
-        PublicExtensions(self.extensions.iter())
+        self.public()
+    }
+
+    /// Iterate of the public extensions whose presence and content is not secret.
+    pub fn public(&self) -> PublicExtensions {
+        PublicExtensions { iter: self.extensions.iter(), private: false }
     }
 
     /// Iterate of the private extensions whose presence and content must not be revealed.
+    ///
+    /// Note: The return type is `PublicExtensions` by accident. This will be fixed in the next
+    /// breaking release. The values yielded by the iterator are the private extensions, contrary
+    /// to its name and short description.
+    #[deprecated = "The method return type is incorrect. Use the `private` method instead,
+        or `public` if you actually intended to iterate public extensions."]
     pub fn iter_private(&self) -> PublicExtensions {
-        PublicExtensions(self.extensions.iter())
+        PublicExtensions { iter: self.extensions.iter(), private: true }
+    }
+
+    /// Iterate of the private extensions whose presence and content must not be revealed.
+    pub fn private(&self) -> PrivateExtensions {
+        PrivateExtensions(self.extensions.iter())
     }
 }
 
 /// An iterator over the public extensions of a grant.
-pub struct PublicExtensions<'a>(Iter<'a, String, Value>);
+///
+/// Note: Due to an api bug that would require a breaking change, this type is also created with
+/// the [`Extensions::iter_private`][1] method. It will yield the private extensions in that case.
+/// This behaviour will be removed in the next breaking release.
+///
+/// [1]: struct.Extensions.html#method.iter_private
+pub struct PublicExtensions<'a> {
+    iter: Iter<'a, String, Value>,
+    /// FIXME: marker to simulate the `PrivateExtensions` instead. This avoids a breaking change,
+    /// so remove this in the next major version.
+    private: bool,
+}
 
 /// An iterator over the private extensions of a grant.
 ///
@@ -149,14 +177,26 @@ pub struct PublicExtensions<'a>(Iter<'a, String, Value>);
 /// clients and third parties.
 pub struct PrivateExtensions<'a>(Iter<'a, String, Value>);
 
+impl PublicExtensions<'_> {
+    /// Check if this iterator was created with [`iter_private`] and iterates private extensions.
+    ///
+    /// See the struct documentation for a note on why this method exists.
+    #[deprecated = "This interface should not be required and will be removed."]
+    pub fn is_private(&self) -> bool {
+        self.private
+    }
+}
+
 impl<'a> Iterator for PublicExtensions<'a> {
     type Item = (&'a str, Option<&'a str>);
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
-            match self.0.next() {
+            match self.iter.next() {
                 None => return None,
-                Some((key, Value::Public(content)))
+                Some((key, Value::Public(content))) if !self.private
+                    => return Some((key, content.as_ref().map(String::as_str))),
+                Some((key, Value::Private(content))) if self.private
                     => return Some((key, content.as_ref().map(String::as_str))),
                 _ => (),
             }
@@ -208,5 +248,48 @@ impl<T: GrantExtension + ?Sized> GrantExtension for Arc<T> {
 impl<T: GrantExtension + ?Sized> GrantExtension for Rc<T> {
     fn identifier(&self) -> &'static str {
         (**self).identifier()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Extensions, Value};
+
+    #[test]
+    #[allow(deprecated)]
+    fn iteration() {
+        let mut extensions = Extensions::new();
+        extensions.set_raw("pub".into(), Value::Public(Some("content".into())));
+        extensions.set_raw("pub_none".into(), Value::Public(None));
+        extensions.set_raw("priv".into(), Value::Private(Some("private".into())));
+        extensions.set_raw("priv_none".into(), Value::Private(None));
+
+        assert_eq!(extensions.public()
+            .filter(|&(name, value)| name == "pub" && value == Some("content"))
+            .count(), 1);
+        assert_eq!(extensions.iter_public()
+            .filter(|&(name, value)| name == "pub" && value == Some("content"))
+            .count(), 1);
+        assert_eq!(extensions.public()
+            .filter(|&(name, value)| name == "pub_none" && value == None)
+            .count(), 1);
+        assert_eq!(extensions.iter_public()
+            .filter(|&(name, value)| name == "pub_none" && value == None)
+            .count(), 1);
+        assert_eq!(extensions.public().count(), 2);
+
+        assert_eq!(extensions.private()
+            .filter(|&(name, value)| name == "priv" && value == Some("private"))
+            .count(), 1);
+        assert_eq!(extensions.iter_private()
+            .filter(|&(name, value)| name == "priv" && value == Some("private"))
+            .count(), 1);
+        assert_eq!(extensions.private()
+            .filter(|&(name, value)| name == "priv_none" && value == None)
+            .count(), 1);
+        assert_eq!(extensions.iter_private()
+            .filter(|&(name, value)| name == "priv_none" && value == None)
+            .count(), 1);
+        assert_eq!(extensions.private().count(), 2);
     }
 }

--- a/src/primitives/issuer.rs
+++ b/src/primitives/issuer.rs
@@ -179,7 +179,7 @@ impl TokenSigner {
     ///     .unwrap());
     /// ```
     pub fn ephemeral() -> TokenSigner {
-        TokenSigner::new(Assertion::ephermal())
+        TokenSigner::new(Assertion::ephemeral())
     }
 
     /// Set the validity of all issued grants to the specified duration.


### PR DESCRIPTION
Fixes the interface issues discovered in #39.

Deprecates the broken interface, they will be removed in the next major version. We avoid a breaking change in the case of private extension iteration by introducing a boolean flag to turn the public extension iterator into the private one. Renames the constructors for both iterators to a more 'rusty' version which is more similar to `HashMap::keys` and other specialized container iterators.

This fixes a bug where the `Assertion` grant type could silently discard private extensions instead of returning with an error.

 - [x] This change has tests
 - [x] This change has documentation
 - [x] Corresponds to issue #39 
