### PR TITLE
Credentials in body

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1520,7 +1520,7 @@ dependencies = [
 [[package]]
 name = "route-recognizer"
 version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/miller-time/route-recognizer.rs?rev=d7bc06d2dc58a2c59d8f2cfbee2ab23b8188700d#d7bc06d2dc58a2c59d8f2cfbee2ab23b8188700d"
 
 [[package]]
 name = "router"
@@ -1528,7 +1528,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "iron 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "route-recognizer 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "route-recognizer 0.1.12 (git+https://github.com/miller-time/route-recognizer.rs?rev=d7bc06d2dc58a2c59d8f2cfbee2ab23b8188700d)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2425,7 +2425,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rocket_codegen 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "79aa1366f9b2eccddc05971e17c5de7bb75a5431eb12c2b5c66545fd348647f4"
 "checksum rocket_http 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b1391457ee4e80b40d4b57fa5765c0f2836b20d73bcbee4e3f35d93cf3b80817"
 "checksum rouille 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "112568052ec17fa26c6c11c40acbb30d3ad244bf3d6da0be181f5e7e42e5004f"
-"checksum route-recognizer 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3255338088df8146ba63d60a9b8e3556f1146ce2973bc05a75181a42ce2256"
+"checksum route-recognizer 0.1.12 (git+https://github.com/miller-time/route-recognizer.rs?rev=d7bc06d2dc58a2c59d8f2cfbee2ab23b8188700d)" = "<none>"
 "checksum router 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dc63b6f3b8895b0d04e816b2b1aa58fdba2d5acca3cbb8f0ab8e017347d57397"
 "checksum rustc-demangle 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "01b90379b8664dd83460d59bdc5dd1fd3172b8913788db483ed1325171eab2f7"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"


### PR DESCRIPTION
Add an **option** to allow the client secrets to be passed in the body 
for access token requests. This must be enabled explicitely in the 
`AccessTokenFlow` instance executing the request.

 - [x] This change has tests
 - [x] This change has documentation
 - [x] Closes: #28 

[Contributing]: CONTRIBUTING.md
