### PR TITLE
Add token refresh flow

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -2,6 +2,17 @@ Versions follow SemVer, of course. Major milestone versions are named in
 alphabetic order and will be accompanied by notes in [the migration
 notes](Migration.md)
 
+# v0.4.5 (2019-???-??) [WIP]
+
+Feature release
+
+Added token refresh
+ - New `RefreshFlow` utilizing the same `Endpoint` trait as other flows.
+ - An empty refresh token in `IssuedToken` is now interpreted as an elided
+   refresh token and the response to the client will not include one.
+ - Dedicated `Issuer::refresh` method with default (error-)impl to generate
+   updated tokens.
+
 # v0.4.4 (2019-Aug-09)
 
 Bugfix release

--- a/Migration.md
+++ b/Migration.md
@@ -25,6 +25,20 @@ has been replaced by `ephemeral`.
 The crate has been split into a core (`oxide-auth`) and several sub-crates for
 each frontend version
 
+The refresh token in `IssuedToken` is now optional. A new attribute for the
+token type of the access token has been added, its enum type has a `Default`
+implementation that generates the `Bearer` corresponding variant.
+
+The `Issuer::refresh` method no longer has a default implementation. To
+replicate the old behaviour, its body should simply consist of `Err(())`.
+
+## v0.4.5
+
+An empty `refresh` token in the `IssuedToken` will no longer inidicate support
+for refreshing to the client. Furthermore, refresh tokens need to be
+explicitely enabled for `TokenSigner` as there is no good way to revoke them
+and are mostly intended for usage in custom signers.
+
 ## v0.4.1
 
 The iron frontend has been reworked greatly. It no longer wraps endpoint

--- a/examples/actix.rs
+++ b/examples/actix.rs
@@ -30,7 +30,7 @@ here</a> to begin the authorization process.
 struct State {
     registrar: Addr<AsActor<ClientMap>>,
     authorizer: Addr<AsActor<AuthMap<RandomGenerator>>>,
-    issuer: Addr<AsActor<TokenSigner>>,
+    issuer: Addr<AsActor<TokenMap<RandomGenerator>>>,
     scopes: &'static [Scope],
 }
 
@@ -46,7 +46,7 @@ pub fn main() {
     clients.register_client(client);
 
     let authorizer = AuthMap::new(RandomGenerator::new(16));
-    let issuer = TokenSigner::ephemeral();
+    let issuer = TokenMap::new(RandomGenerator::new(16));
 
     let scopes = vec!["default".parse().unwrap()].into_boxed_slice();
     // Emulate static initialization for complex type

--- a/examples/actix.rs
+++ b/examples/actix.rs
@@ -14,7 +14,7 @@ use actix_web::{server, App, HttpRequest, HttpResponse};
 use futures::{Future, future};
 
 use oxide_auth::frontends::actix::{AsActor, OAuth, OAuthFailure, OAuthResponse, OwnerConsent, PreGrant, ResourceProtection};
-use oxide_auth::frontends::actix::{authorization, access_token, resource};
+use oxide_auth::frontends::actix::{authorization, access_token, refresh, resource};
 use oxide_auth::frontends::simple::endpoint::FnSolicitor;
 use oxide_auth::primitives::prelude::*;
 

--- a/examples/actix.rs
+++ b/examples/actix.rs
@@ -45,7 +45,15 @@ pub fn main() {
         "default".parse().unwrap()); // Allowed client scope
     clients.register_client(client);
 
+    // Authorization tokens are 16 byte random keys to a memory hash map.
     let authorizer = AuthMap::new(RandomGenerator::new(16));
+
+    // Bearer tokens are also random generated but 256-bit tokens, since they live longer and this
+    // example is somewhat paranoid.
+    //
+    // We could also use a `TokenSigner::ephemeral` here to create signed tokens which can be read
+    // and parsed by anyone, but not maliciously created. However, they can not be revoked and thus
+    // don't offer even longer lived refresh tokens.
     let issuer = TokenMap::new(RandomGenerator::new(16));
 
     let scopes = vec!["default".parse().unwrap()].into_boxed_slice();

--- a/examples/rocket.rs
+++ b/examples/rocket.rs
@@ -119,7 +119,14 @@ impl MyState {
                     "http://localhost:8000/clientside/endpoint".parse().unwrap(),
                     "default-scope".parse().unwrap())
             ].into_iter().collect()),
+            // Authorization tokens are 16 byte random keys to a memory hash map.
             authorizer: Mutex::new(AuthMap::new(RandomGenerator::new(16))),
+            // Bearer tokens are also random generated but 256-bit tokens, since they live longer
+            // and this example is somewhat paranoid.
+            //
+            // We could also use a `TokenSigner::ephemeral` here to create signed tokens which can
+            // be read and parsed by anyone, but not maliciously created. However, they can not be
+            // revoked and thus don't offer even longer lived refresh tokens.
             issuer: Mutex::new(TokenMap::new(RandomGenerator::new(16))),
         }
     }

--- a/examples/rocket.rs
+++ b/examples/rocket.rs
@@ -22,7 +22,7 @@ use rocket::response::Responder;
 struct MyState {
     registrar: Mutex<ClientMap>,
     authorizer: Mutex<AuthMap<RandomGenerator>>,
-    issuer: Mutex<TokenSigner>,
+    issuer: Mutex<TokenMap<RandomGenerator>>,
 }
 
 #[get("/authorize")]
@@ -120,7 +120,7 @@ impl MyState {
                     "default-scope".parse().unwrap())
             ].into_iter().collect()),
             authorizer: Mutex::new(AuthMap::new(RandomGenerator::new(16))),
-            issuer: Mutex::new(TokenSigner::ephemeral()),
+            issuer: Mutex::new(TokenMap::new(RandomGenerator::new(16))),
         }
     }
 

--- a/examples/rocket.rs
+++ b/examples/rocket.rs
@@ -57,6 +57,17 @@ fn token<'r>(mut oauth: OAuthRequest<'r>, body: Data, state: State<MyState>)
         .map_err(|err| err.pack::<OAuthFailure>())
 }
 
+#[post("/refresh", data="<body>")]
+fn refresh<'r>(mut oauth: OAuthRequest<'r>, body: Data, state: State<MyState>)
+    -> Result<Response<'r>, OAuthFailure>
+{
+    oauth.add_body(body);
+    state.endpoint()
+        .to_refresh()
+        .execute(oauth)
+        .map_err(|err| err.pack::<OAuthFailure>())
+}
+
 #[get("/")]
 fn protected_resource<'r>(oauth: OAuthRequest<'r>, state: State<MyState>)
     -> impl Responder<'r>
@@ -91,7 +102,8 @@ fn main() {
             authorize,
             authorize_consent,
             token,
-            protected_resource
+            protected_resource,
+            refresh,
         ])
         // We only attach the test client here because there can only be one rocket.
         .attach(support::ClientFairing)

--- a/examples/rouille.rs
+++ b/examples/rouille.rs
@@ -9,7 +9,7 @@ mod support;
 use std::sync::Mutex;
 use std::thread;
 
-use oxide_auth::endpoint::{AuthorizationFlow, AccessTokenFlow, OwnerConsent, PreGrant, ResourceFlow};
+use oxide_auth::endpoint::{AuthorizationFlow, AccessTokenFlow, OwnerConsent, PreGrant, RefreshFlow, ResourceFlow};
 use oxide_auth::frontends::rouille::{FnSolicitor, GenericEndpoint};
 use oxide_auth::primitives::prelude::*;
 use rouille::{Request, Response, ResponseBody, Server};
@@ -81,6 +81,13 @@ here</a> to begin the authorization process.
             (POST) ["/token"] => {
                 let mut locked = endpoint.lock().unwrap();
                 AccessTokenFlow::prepare(&mut *locked)
+                    .expect("Can not fail")
+                    .execute(request)
+                    .unwrap_or_else(|_| Response::empty_400())
+            },
+            (POST) ["/refresh"] => {
+                let mut locked = endpoint.lock().unwrap();
+                RefreshFlow::prepare(&mut *locked)
                     .expect("Can not fail")
                     .execute(request)
                     .unwrap_or_else(|_| Response::empty_400())

--- a/examples/rouille.rs
+++ b/examples/rouille.rs
@@ -30,8 +30,13 @@ pub fn main() {
     // Authorization tokens are 16 byte random keys to a memory hash map.
     let authorizer = AuthMap::new(RandomGenerator::new(16));
 
-    // Bearer tokens are signed (but not encrypted) using a passphrase.
-    let issuer = TokenSigner::ephemeral();
+    // Bearer tokens are also random generated but 256-bit tokens, since they live longer and this
+    // example is somewhat paranoid.
+    //
+    // We could also use a `TokenSigner::ephemeral` here to create signed tokens which can be read
+    // and parsed by anyone, but not maliciously created. However, they can not be revoked and thus
+    // don't offer even longer lived refresh tokens.
+    let issuer = TokenMap::new(RandomGenerator::new(32));
 
     let endpoint = Mutex::new(GenericEndpoint {
         registrar,
@@ -103,7 +108,7 @@ here</a> to begin the authorization process.
     );
     // Start a dummy client instance which simply relays the token/response
     let client = thread::spawn(||
-        Server::new(("localhost", 8021), support::dummy_client)
+        Server::new(("localhost", 8021), support::dummy_client())
             .expect("Failed to start client")
             .run()
     );

--- a/examples/support/actix.rs
+++ b/examples/support/actix.rs
@@ -1,39 +1,29 @@
-extern crate reqwest;
 extern crate actix_web;
-extern crate serde;
-extern crate serde_json;
 
 #[path="generic.rs"]
 mod generic;
 
-pub use self::generic::*;
+pub use self::generic::{Client, ClientConfig, ClientError, open_in_browser, consent_page_html};
 
-use self::reqwest::{header, Response};
 use self::actix_web::*;
 use self::actix_web::App;
 
-use std::fmt;
-use std::collections::HashMap;
-use std::io::Read;
-use std::sync::{Arc, RwLock};
+pub fn dummy_client() -> App<Client> {
+    let config = ClientConfig {
+        client_id: "LocalClient".into(),
+        protected_url: "http://localhost:8020/".into(),
+        token_url: "http://localhost:8020/token".into(),
+        refresh_url: "http://localhost:8020/refresh".into(),
+        redirect_uri: "http://localhost:8021/endpoint".into(),
+    };
 
-#[derive(Debug, Default)]
-pub struct State {
-    token: Option<String>,
-    refresh: Option<String>,
-    until: Option<String>,
-}
-
-type AppState = Arc<RwLock<State>>;
-
-pub fn dummy_client() -> App<AppState> {
-    App::with_state(AppState::default())
+    App::with_state(Client::new(config))
         .route("/endpoint", http::Method::GET, endpoint_impl)
         .route("/refresh", http::Method::POST, refresh)
         .route("/", http::Method::GET, get_with_token)
 }
 
-fn endpoint_impl(request: HttpRequest<AppState>) -> HttpResponse {
+fn endpoint_impl(request: HttpRequest<Client>) -> HttpResponse {
     if let Some(cause) = request.query().get("error") {
         return HttpResponse::BadRequest()
             .body(format!("Error during owner authorization: {:?}", cause))
@@ -45,120 +35,25 @@ fn endpoint_impl(request: HttpRequest<AppState>) -> HttpResponse {
         Some(code) => code.clone(),
     };
 
-    // Construct a request against http://localhost:8020/token, the access token endpoint
-    let client = reqwest::Client::new();
-    let mut params = HashMap::new();
-    params.insert("grant_type", "authorization_code");
-    params.insert("client_id", "LocalClient");
-    params.insert("code", &code);
-    params.insert("redirect_uri", "http://localhost:8021/endpoint");
-    let access_token_request = client
-        .post("http://localhost:8020/token")
-        .form(&params).build().unwrap();
-
-    let token_response = match client.execute(access_token_request) {
-        Ok(response) => response,
-        Err(_) => return HttpResponse::BadRequest()
-            .body("Could not fetch bearer token"),
-    };
-
-    let token_map = match parse_response(token_response) {
-        Ok(map) => map,
-        Err(err) => return err,
-    };
-
-    if token_map.get("error").is_some() || !token_map.get("access_token").is_some() {
-        return HttpResponse::BadRequest()
-            .body(format!("Response contains neither error nor access token: {:?}", token_map));
+    match request.state().authorize(&code) {
+        Ok(()) => HttpResponse::Found().header("Location", "/").finish(),
+        Err(err) => HttpResponse::InternalServerError().body(format!("{}", err)),
     }
-
-    let token = token_map.get("access_token").unwrap();
-
-    let mut set_map = request.state().write().unwrap();
-    set_map.token = Some(token.to_string());
-    set_map.refresh = token_map
-        .get("refresh_token")
-        .cloned();
-    set_map.until = token_map
-        .get("expires_in")
-        .cloned();
-
-    HttpResponse::Found()
-        .header("Location", "/")
-        .finish()
 }
 
-fn refresh(request: HttpRequest<AppState>) -> HttpResponse {
-    let refresh = match request.state().read().unwrap().refresh.clone() {
-        Some(refresh) => refresh,
-        None => return HttpResponse::BadRequest()
-            .body("No refresh token was issued"),
-    };
-
-    let client = reqwest::Client::new();
-    let mut params = HashMap::new();
-    params.insert("grant_type", "refresh_token");
-    params.insert("client_id", "LocalClient");
-    params.insert("refresh_token", &refresh);
-    let access_token_request = client
-        .post("http://localhost:8020/refresh")
-        .form(&params).build().unwrap();
-
-    let token_response = match client.execute(access_token_request) {
-        Ok(response) => response,
-        Err(_) => return HttpResponse::BadRequest()
-            .body("Could not refresh bearer token"),
-    };
-
-    let token_map = match parse_response(token_response) {
-        Ok(map) => map,
-        Err(err) => return err,
-    };
-
-    if token_map.get("error").is_some() || !token_map.get("access_token").is_some() {
-        return HttpResponse::BadRequest()
-            .body(format!("Response contains neither error nor access token: {:?}", token_map));
+fn refresh(request: HttpRequest<Client>) -> HttpResponse {
+    match request.state().refresh() {
+        Ok(()) => HttpResponse::Found().header("Location", "/").finish(),
+        Err(err) => HttpResponse::InternalServerError().body(format!("{}", err)),
     }
-
-    let token = token_map.get("access_token").unwrap();
-
-    let mut set_map = request.state().write().unwrap();
-    set_map.token = Some(token.to_string());
-    set_map.refresh = token_map
-        .get("refresh_token")
-        .cloned()
-        .or(set_map.refresh.take());
-    set_map.until = token_map
-        .get("expires_in")
-        .cloned();
-
-    HttpResponse::Found()
-        .header("Location", "/")
-        .finish()
 }
 
-fn get_with_token(request: HttpRequest<AppState>) -> HttpResponse {
-    let state = request.state().read().unwrap();
-
-    let token = match state.token {
-        None => return HttpResponse::Ok().body("No token yet"),
-        Some(ref token) => token,
+fn get_with_token(request: HttpRequest<Client>) -> HttpResponse {
+    let state = request.state();
+    let protected_page = match state.retrieve_protected_page() {
+        Ok(page) => page,
+        Err(err) => return HttpResponse::InternalServerError().body(format!("{}", err)),
     };
-
-    let client = reqwest::Client::new();
-    // Request the page with the oauth token
-    let page_request = client
-        .get("http://localhost:8020/")
-        .header(header::AUTHORIZATION, "Bearer ".to_string() + token)
-        .build()
-        .unwrap();
-    let mut page_response = match client.execute(page_request) {
-        Ok(response) => response,
-        Err(_) => return HttpResponse::BadRequest()
-            .body("Could not access protected resource"),
-    };
-    let mut protected_page = String::new();
-    page_response.read_to_string(&mut protected_page).unwrap();
 
     let display_page = format!(
         "<html><style>
@@ -172,28 +67,10 @@ fn get_with_token(request: HttpRequest<AppState>) -> HttpResponse {
         Its contents are:
         <article>{}</article>
         <form action=\"refresh\" method=\"post\"><button>Refresh token</button></form>
-        </main></html>", state, protected_page);
+        </main></html>", state.as_html(), protected_page);
 
     HttpResponse::Ok()
         .content_type("text/html")
         .body(display_page)
 }
 
-fn parse_response(mut response: Response) -> Result<HashMap<String, String>, HttpResponse> {
-    let mut token = String::new();
-    response.read_to_string(&mut token).unwrap();
-    serde_json::from_str(&token).map_err(|err| {
-        HttpResponse::BadRequest()
-            .body(format!("Error unwrapping json response, got {:?} instead", err))
-    })
-}
-
-impl fmt::Display for State {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str("Token {<br>")?;
-        write!(f, "&nbsp;token: {:?},<br>", self.token)?;
-        write!(f, "&nbsp;refresh: {:?},<br>", self.refresh)?;
-        write!(f, "&nbsp;expires_in: {:?},<br>", self.until)?;
-        f.write_str("}")
-    }
-}

--- a/examples/support/actix.rs
+++ b/examples/support/actix.rs
@@ -28,12 +28,12 @@ type AppState = Arc<RwLock<State>>;
 
 pub fn dummy_client() -> App<AppState> {
     App::with_state(AppState::default())
-        .route("/endpoint", http::Method::GET, |req| endpoint_impl(&req))
-        .route("/refresh", http::Method::POST, |req| refresh(&req))
-        .route("/", http::Method::GET, |req| get_with_token(&req))
+        .route("/endpoint", http::Method::GET, endpoint_impl)
+        .route("/refresh", http::Method::POST, refresh)
+        .route("/", http::Method::GET, get_with_token)
 }
 
-fn endpoint_impl(request: &HttpRequest<AppState>) -> HttpResponse {
+fn endpoint_impl(request: HttpRequest<AppState>) -> HttpResponse {
     if let Some(cause) = request.query().get("error") {
         return HttpResponse::BadRequest()
             .body(format!("Error during owner authorization: {:?}", cause))
@@ -88,7 +88,7 @@ fn endpoint_impl(request: &HttpRequest<AppState>) -> HttpResponse {
         .finish()
 }
 
-fn refresh(request: &HttpRequest<AppState>) -> HttpResponse {
+fn refresh(request: HttpRequest<AppState>) -> HttpResponse {
     let refresh = match request.state().read().unwrap().refresh.clone() {
         Some(refresh) => refresh,
         None => return HttpResponse::BadRequest()
@@ -137,7 +137,7 @@ fn refresh(request: &HttpRequest<AppState>) -> HttpResponse {
         .finish()
 }
 
-fn get_with_token(request: &HttpRequest<AppState>) -> HttpResponse {
+fn get_with_token(request: HttpRequest<AppState>) -> HttpResponse {
     let state = request.state().read().unwrap();
 
     let token = match state.token {

--- a/examples/support/client.rs
+++ b/examples/support/client.rs
@@ -1,0 +1,210 @@
+extern crate reqwest;
+extern crate serde;
+extern crate serde_json;
+
+use std::fmt;
+use std::collections::HashMap;
+use std::io::Read;
+use std::sync::{Arc, RwLock};
+
+use self::reqwest::{header, Response};
+
+/// Send+Sync client implementation.
+pub struct Client {
+    config: Config,
+    state: Arc<RwLock<State>>,
+}
+
+pub struct Config {
+    /// The protected page.
+    pub protected_url: String,
+
+    /// Url to post to in order to get a token.
+    pub token_url: String,
+
+    /// Url to post to in order to refresh the token.
+    pub refresh_url: String,
+
+    /// The id that the client should use.
+    pub client_id: String,
+
+    /// The redirect_uri to use.
+    pub redirect_uri: String,
+}
+
+pub enum Error {
+    /// The token was not valid for the access.
+    AccessFailed,
+
+    /// No token has been setup yet.
+    NoToken,
+
+    /// The bearer token could not be retrieved, bad request.
+    AuthorizationFailed,
+
+    /// The bearer token could not be retrieved, bad request.
+    RefreshFailed,
+
+    /// The answer should have been json but wasn't.
+    Invalid(serde_json::Error),
+
+    /// The answer did not contain a token.
+    MissingToken,
+
+    /// The token response indicates an error.
+    Response(String),
+}
+
+#[derive(Debug, Default)]
+struct State {
+    pub token: Option<String>,
+    pub refresh: Option<String>,
+    pub until: Option<String>,
+}
+
+impl Client {
+    pub fn new(config: Config) -> Self {
+        Client {
+            config,
+            state: Arc::new(RwLock::new(State::default())),
+        }
+    }
+
+    pub fn authorize(&self, code: &str) -> Result<(), Error> {
+        // Construct a request against http://localhost:8020/token, the access token endpoint
+        let client = reqwest::Client::new();
+
+        let mut state = self.state.write().unwrap();
+
+        let mut params = HashMap::new();
+        params.insert("grant_type", "authorization_code");
+        params.insert("client_id", &self.config.client_id);
+        params.insert("code", code);
+        params.insert("redirect_uri", &self.config.redirect_uri);
+        let access_token_request = client
+            .post(&self.config.token_url)
+            .form(&params).build().unwrap();
+
+        let token_response = client
+            .execute(access_token_request)
+            .map_err(|_| Error::AuthorizationFailed)?;
+        let mut token_map = parse_token_response(token_response)?;
+
+        if let Some(err) = token_map.remove("error") {
+            return Err(Error::Response(err));
+        }
+
+        if let Some(token) = token_map.remove("access_token") {
+            state.token = Some(token);
+            state.refresh = token_map.remove("refresh_token");
+            state.until = token_map.remove("expires_in");
+            return Ok(());
+        }
+
+        Err(Error::MissingToken)
+    }
+
+    pub fn retrieve_protected_page(&self) -> Result<String, Error> {
+        let client = reqwest::Client::new();
+
+        let state = self.state.read().unwrap();
+        let token = match state.token {
+            Some(ref token) => token,
+            None => return Err(Error::NoToken),
+        };
+
+        // Request the page with the oauth token
+        let page_request = client
+            .get(&self.config.protected_url)
+            .header(header::AUTHORIZATION, "Bearer ".to_string() + token)
+            .build()
+            .unwrap();
+
+        let mut page_response = match client.execute(page_request) {
+            Ok(response) => response,
+            Err(_) => return Err(Error::AccessFailed),
+        };
+
+        let mut protected_page = String::new();
+        page_response.read_to_string(&mut protected_page).unwrap();
+        Ok(protected_page)
+    }
+
+    pub fn refresh(&self) -> Result<(), Error> {
+        let client = reqwest::Client::new();
+
+        let mut state = self.state.write().unwrap();
+        let refresh = match state.refresh {
+            Some(ref refresh) => refresh.clone(),
+            None => return Err(Error::NoToken),
+        };
+
+        let mut params = HashMap::new();
+        params.insert("grant_type", "refresh_token");
+        params.insert("client_id", &self.config.client_id);
+        params.insert("refresh_token", &refresh);
+        let access_token_request = client
+            .post(&self.config.refresh_url)
+            .form(&params).build().unwrap();
+
+        let token_response = client
+            .execute(access_token_request)
+            .map_err(|_| Error::RefreshFailed)?;
+        let mut token_map = parse_token_response(token_response)?;
+
+        if token_map.get("error").is_some() || !token_map.get("access_token").is_some() {
+            return Err(Error::MissingToken);
+        }
+
+        let token = token_map
+            .remove("access_token")
+            .unwrap();
+        state.token = Some(token);
+        state.refresh = token_map
+            .remove("refresh_token")
+            .or(state.refresh.take());
+        state.until = token_map
+            .remove("expires_in");
+        Ok(())
+    }
+
+    pub fn as_html(&self) -> String {
+        format!("{}", self.state.read().unwrap())
+    }
+}
+
+fn parse_token_response(mut response: Response) -> Result<HashMap<String, String>, serde_json::Error> {
+    let mut token = String::new();
+    response.read_to_string(&mut token).unwrap();
+    serde_json::from_str(&token)
+}
+
+impl From<serde_json::Error> for Error {
+    fn from(err: serde_json::Error) -> Self {
+        Error::Invalid(err)
+    }
+}
+
+impl fmt::Display for State {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("Token {<br>")?;
+        write!(f, "&nbsp;token: {:?},<br>", self.token)?;
+        write!(f, "&nbsp;refresh: {:?},<br>", self.refresh)?;
+        write!(f, "&nbsp;expires_in: {:?},<br>", self.until)?;
+        f.write_str("}")
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Error::AuthorizationFailed => f.write_str("Could not fetch bearer token"),
+            Error::NoToken => f.write_str("No token with which to access protected page"),
+            Error::AccessFailed => f.write_str("Access token failed to authorize for protected page"),
+            Error::RefreshFailed => f.write_str("Could not refresh bearer token"),
+            Error::Invalid(serde) => write!(f, "Bad json response: {}", serde),
+            Error::MissingToken => write!(f, "No token nor error in server response"),
+            Error::Response(err) => write!(f, "Server error while fetching token: {}", err),
+        }
+    }
+}

--- a/examples/support/generic.rs
+++ b/examples/support/generic.rs
@@ -10,7 +10,13 @@
 //! a page in the browser.
 #![allow(unused)]
 
+/// Simplistic reqwest client.
+mod client;
+
 use oxide_auth::endpoint::PreGrant;
+use std::fmt;
+
+pub use self::client::{Client, Config as ClientConfig, Error as ClientError};
 
 /// Try to open the server url `http://localhost:8020` in the browser, or print a guiding statement
 /// to the console if this is not possible.

--- a/examples/support/rocket.rs
+++ b/examples/support/rocket.rs
@@ -1,27 +1,16 @@
-extern crate reqwest;
 extern crate rocket;
-extern crate serde_urlencoded;
-extern crate serde;
-extern crate serde_json;
 
 #[path = "generic.rs"]
 mod generic;
 
-pub use self::generic::*;
+use self::generic::{Client, ClientConfig, ClientError};
 
-use self::reqwest::header;
-use rocket::{Request, Rocket, State};
+use rocket::{Rocket, State};
 use rocket::fairing::{Fairing, Info, Kind};
-use rocket::http::{Status};
-use rocket::response::Redirect;
-use rocket::response::content::Html;
-use rocket::response::status::Custom;
-use rocket::request::{self, FromRequest};
+use rocket::http::Status;
+use rocket::response::{Redirect, content::Html, status::Custom};
 
-use std::collections::HashMap;
-use std::io::{Read};
-use std::sync::{Mutex, MutexGuard};
-
+pub use self::generic::consent_page_html;
 pub struct ClientFairing;
 
 impl Fairing for ClientFairing {
@@ -33,48 +22,43 @@ impl Fairing for ClientFairing {
     }
 
     fn on_attach(&self, rocket: Rocket) -> Result<Rocket, Rocket> {
+        let config = ClientConfig {
+            client_id: "LocalClient".into(),
+            protected_url: "http://localhost:8000/".into(),
+            token_url: "http://localhost:8000/token".into(),
+            refresh_url: "http://localhost:8000/refresh".into(),
+            redirect_uri: "http://localhost:8000/clientside/endpoint".into(),
+        };
         Ok(rocket
-            .manage(ClientState {
-                token: Mutex::new(None),
-            })
+            .manage(Client::new(config))
             .mount("/clientside", routes![oauth_endpoint, client_view, client_debug]))
     }
 }
 
-struct ClientState {
-    token: Mutex<Option<String>>,
-}
-
-struct Token<'r> {
-    inner: MutexGuard<'r, Option<String>>,
-}
-
 #[get("/endpoint?<code>&<error>")]
-fn oauth_endpoint<'r>(code: Option<String>, error: Option<String>, mut guard: Token<'r>)
-    -> Result<Redirect, String> 
+fn oauth_endpoint<'r>(code: Option<String>, error: Option<String>, state: State<Client>)
+    -> Result<Redirect, Custom<String>> 
 {
     if let Some(error) = error {
-        return Err(format!("Error during owner authorization: {:?}", error))
-    }
-    if let Some(code) = code {
-        let token = retrieve_token(code)?;
-        *guard.inner = Some(token);
-        return Ok(Redirect::found("/clientside"))
+        return Err(Custom(Status::InternalServerError, 
+            format!("Error during owner authorization: {:?}", error)))
     }
 
-    Err(format!("Endpoint hit without an authorization code"))
+    let code = code
+        .ok_or_else(|| Custom(Status::BadRequest, 
+            "Endpoint hit without an authorization code".into()))?;
+    state.authorize(&code)
+        .map_err(internal_error)?;
+
+    Ok(Redirect::found("/clientside"))
 }
 
 #[get("/")]
-fn client_view<'r>(guard: Token<'r>) -> Result<Html<String>, Custom<&'static str>> {
-    let token = match *guard.inner {
-        Some(ref token) => token,
-        None => return Err(Custom(Status::PreconditionFailed, "No token retrieved yet")),
-    };
+fn client_view(state: State<Client>) -> Result<Html<String>, Custom<String>> {
+    let protected_page = state
+        .retrieve_protected_page()
+        .map_err(internal_error)?;
 
-    let protected_page = retrieve_protected_page(token)
-        .unwrap_or_else(|err| format!("Error: {}", err));
-    let token = token.replace(",", ",</br>");
     let display_page = format!(
         "<html><style>
             aside{{overflow: auto; word-break: keep-all; white-space: nowrap}}
@@ -83,82 +67,19 @@ fn client_view<'r>(guard: Token<'r>) -> Result<Html<String>, Custom<&'static str
         </style>
         <main>
         Used token <aside style>{}</aside> to access
-        <a href=\"http://localhost:8020/\">http://localhost:8020/</a>.
+        <a href=\"http://localhost:8000/\">http://localhost:8000/</a>.
         Its contents are:
         <article>{:?}</article>
-        </main></html>", token, protected_page);
+        </main></html>", state.as_html(), protected_page);
 
     Ok(Html(display_page))
 }
 
 #[get("/debug")]
-fn client_debug<'r>(guard: Token<'r>) -> String {
-    match *guard.inner {
-        Some(ref token) => token.to_owned(),
-        None => "".to_owned(),
-    }
+fn client_debug(state: State<Client>) -> Html<String> {
+    Html(state.as_html())
 }
 
-fn retrieve_token(code: String) -> Result<String, String> {
-    // Construct a request against http://localhost:8020/token, the access token endpoint
-    let client = reqwest::Client::new();
-
-    let mut params = HashMap::new();
-    params.insert("grant_type", "authorization_code");
-    params.insert("client_id", "LocalClient");
-    params.insert("code", &code);
-    params.insert("redirect_uri", "http://localhost:8000/clientside/endpoint");
-    let access_token_request = client
-        .post("http://localhost:8000/token")
-        .form(&params).build().unwrap();
-    let mut token_response = match client.execute(access_token_request) {
-        Ok(response) => response,
-        Err(_) => return Err("Could not fetch bearer token".into()),
-    };
-
-    let mut token = String::new();
-    token_response.read_to_string(&mut token).unwrap();
-    let token_map: HashMap<String, String> = match serde_json::from_str(&token) {
-        Ok(token_map) => token_map,
-        Err(err) => return Err(format!("Error unwrapping json response, got {:?} instead", err)),
-    };
-
-    if let Some(err) = token_map.get("error") {
-        return Err(format!("Error fetching bearer token: {:?}", err))
-    }
-
-    if let Some(token) = token_map.get("access_token") {
-        return Ok(token.to_owned())
-    }
-
-    Err("Token response neither error nor token".into())
-}
-
-fn retrieve_protected_page(token: &str) -> Result<String, String> {
-    let client = reqwest::Client::new();
-
-    // Request the page with the oauth token
-    let page_request = client
-        .get("http://localhost:8000/")
-        .header(header::AUTHORIZATION, "Bearer ".to_string() + token)
-        .build()
-        .unwrap();
-
-    let mut page_response = match client.execute(page_request) {
-        Ok(response) => response,
-        Err(_) => return Err("Could not access protected resource".into()),
-    };
-
-    let mut protected_page = String::new();
-    page_response.read_to_string(&mut protected_page).unwrap();
-    Ok(protected_page)
-}
-
-impl<'a, 'r> FromRequest<'a, 'r> for Token<'r> {
-    type Error = ();
-
-    fn from_request(request: &'a Request<'r>) -> request::Outcome<Self, Self::Error> {
-        request.guard::<State<'r, ClientState>>()
-            .map(|ok| Token { inner: ok.inner().token.lock().unwrap(), })
-    }
+fn internal_error(err: ClientError) -> Custom<String> {
+    Custom(Status::InternalServerError, err.to_string())
 }

--- a/examples/support/rocket.rs
+++ b/examples/support/rocket.rs
@@ -31,7 +31,7 @@ impl Fairing for ClientFairing {
         };
         Ok(rocket
             .manage(Client::new(config))
-            .mount("/clientside", routes![oauth_endpoint, client_view, client_debug]))
+            .mount("/clientside", routes![oauth_endpoint, client_view, client_debug, refresh]))
     }
 }
 
@@ -70,9 +70,17 @@ fn client_view(state: State<Client>) -> Result<Html<String>, Custom<String>> {
         <a href=\"http://localhost:8000/\">http://localhost:8000/</a>.
         Its contents are:
         <article>{:?}</article>
+        <form action=\"/clientside/refresh\" method=\"post\"><button>Refresh token</button></form>
         </main></html>", state.as_html(), protected_page);
 
     Ok(Html(display_page))
+}
+
+#[post("/refresh")]
+fn refresh(state: State<Client>) -> Result<Redirect, Custom<String>> {
+    state.refresh()
+        .map_err(internal_error)
+        .map(|()| Redirect::found("/clientside"))
 }
 
 #[get("/debug")]

--- a/examples/support/rouille.rs
+++ b/examples/support/rouille.rs
@@ -4,56 +4,47 @@ extern crate serde_urlencoded;
 extern crate serde;
 extern crate serde_json;
 
+#[path="generic.rs"]
 mod generic;
 
-pub use self::generic::*;
+pub use self::generic::{Client, ClientConfig, ClientError};
+pub use self::generic::{consent_page_html, open_in_browser};
 
-use self::reqwest::header;
 use self::rouille::{Request, Response};
 
-use std::collections::HashMap;
-use std::io::Read;
+pub fn dummy_client()
+    -> impl (Fn(&Request) -> Response) + 'static
+{
+    let client = Client::new(ClientConfig {
+        client_id: "LocalClient".into(),
+        protected_url: "http://localhost:8020/".into(),
+        token_url: "http://localhost:8020/token".into(),
+        refresh_url: "http://localhost:8020/refresh".into(),
+        redirect_uri: "http://localhost:8021/endpoint".into(),
+    });
 
-pub fn dummy_client(request: &Request) -> Response {
-    if let Some(cause) = request.get_param("error") {
-        return Response::text(format!("Error during owner authorization: {:?}", cause))
+    move |request| {
+        router!(request,
+            (GET) ["/"] => {
+                client_impl(&client, request)
+            },
+            (GET) ["/endpoint"] => {
+                endpoint_impl(&client, request)
+            },
+            (POST) ["/refresh"] => {
+                refresh_impl(&client, request)
+            },
+            _ => Response::empty_404(),
+        )
     }
+}
 
-    let code = match request.get_param("code") {
-        None => return Response::text("Missing code").with_status_code(400),
-        Some(code) => code,
+pub fn client_impl(client: &Client, _: &Request) -> Response {
+    let protected_page = match client.retrieve_protected_page() {
+        Ok(page) => page,
+        Err(err) => return internal_error(err),
     };
 
-    // Construct a request against http://localhost:8020/token, the access token endpoint
-    let client = reqwest::Client::new();
-    let mut params = HashMap::new();
-    params.insert("grant_type", "authorization_code");
-    params.insert("client_id", "LocalClient");
-    params.insert("code", &code);
-    params.insert("redirect_uri", "http://localhost:8021/endpoint");
-    let access_token_request = client
-        .post("http://localhost:8020/token")
-        .form(&params).build().unwrap();
-    let mut token_response = client.execute(access_token_request).unwrap();
-    let mut token = String::new();
-    token_response.read_to_string(&mut token).unwrap();
-    let token_map: HashMap<String, String> = serde_json::from_str(&token).unwrap();
-
-    if token_map.get("error").is_some() || !token_map.get("access_token").is_some() {
-        return Response::text(token).with_status_code(400);
-    }
-
-    // Request the page with the oauth token
-    let page_request = client
-        .get("http://localhost:8020/")
-        .header(header::AUTHORIZATION, "Bearer ".to_string() + token_map.get("access_token").unwrap())
-        .build().unwrap();
-    let mut page_response = client.execute(page_request).unwrap();
-    let mut protected_page = String::new();
-    page_response.read_to_string(&mut protected_page).unwrap();
-
-    let token = serde_json::to_string_pretty(&token_map).unwrap();
-    let token = token.replace(",", ",</br>");
     let display_page = format!(
         "<html><style>
             aside{{overflow: auto; word-break: keep-all; white-space: nowrap}}
@@ -64,9 +55,39 @@ pub fn dummy_client(request: &Request) -> Response {
         Used token <aside style>{}</aside> to access
         <a href=\"http://localhost:8020/\">http://localhost:8020/</a>.
         Its contents are:
-        <article>{}</article>
-        </main></html>", token, protected_page);
+        <article>{:?}</article>
+        <form action=\"/refresh\" method=\"post\"><button>Refresh token</button></form>
+        </main></html>", client.as_html(), protected_page);
 
     Response::html(display_page)
         .with_status_code(200)
+}
+
+fn endpoint_impl(client: &Client, request: &Request) -> Response {
+    if let Some(error) = request.get_param("error") {
+        return Response::text(format!("Error during owner authorization: {:?}", error))
+            .with_status_code(400);
+    }
+
+    let code = match request.get_param("code") {
+        Some(code) => code,
+        None => return Response::text("Endpoint hit without an authorization code")
+            .with_status_code(400),
+    };
+
+    if let Err(err) = client.authorize(&code) {
+        return internal_error(err);
+    }
+
+    Response::redirect_303("/")
+}
+
+fn refresh_impl(client: &Client, _: &Request) -> Response {
+    client.refresh()
+        .err()
+        .map_or_else(|| Response::redirect_303("/"), internal_error)
+}
+
+fn internal_error(error: ClientError) -> Response {
+    Response::text(error.to_string()).with_status_code(500)
 }

--- a/release
+++ b/release
@@ -11,6 +11,10 @@ check_notexists_version() {
 	[[ $(wget -U "%final_agent" "https://crates.io/api/v1/crates/oxide-auth/$new_version" -qO -) == "{\"errors\":"* ]]
 }
 
+git_considered_clean() {
+	[[ -z $(git status -s) ]]
+}
+
 count_wip_marker() {
 	# WIP alone is not a marker
 	[[ -z $(grep "\[WIP\]" Migration.md Readme.md) ]]
@@ -18,6 +22,13 @@ count_wip_marker() {
 
 check_release_changes() {
 	[[ -z $(grep "# v$new_version" Changes.md) ]]
+}
+
+check_target_features() {
+	cargo build --no-default-features --features="actix-frontend" --example actix &&
+	cargo +nightly build --no-default-features --features="rocket-frontend" --example rocket &&
+	cargo build --no-default-features --features="iron-frontend" --example iron &&
+	cargo build --no-default-features --features="rouille-frontend" --example rouille
 }
 
 make_git_tag() {
@@ -60,7 +71,7 @@ exit 1; } ;;
 done
 
 # Check that the working dir is clean. May comment this out if it produces problems.
-[[ -z $(git status -s) ]] || { echo "Fail: Working directory is not clean"; exit 1; }
+git_considered_clean || { echo "Fail: Working directory is not clean"; exit 1; }
 
 # Check that for every author, we have at least name or mail recorded in Contributors.txt
 # For each commit author, checks that either his/her name or respective mail
@@ -83,5 +94,7 @@ check_release_changes && { echo "Fail: No changelog regarding this release"; exi
 
 # Packaging works. Note: does not publish the version.
 cargo package || { echo "Fail: cargo could not package successfully"; exit 1; }
+
+check_target_features || { echo "Fail: one or more required target-feature combinations doesnt compile its example properly"; exit 1; }
 
 [[ -z $do_tag ]] || make_git_tag

--- a/src/code_grant/accesstoken.rs
+++ b/src/code_grant/accesstoken.rs
@@ -355,7 +355,7 @@ impl BearerToken {
         struct Serial<'a> {
             access_token: &'a str,
             #[serde(skip_serializing_if="Option::is_none")]
-            refresh: Option<&'a str>,
+            refresh_token: Option<&'a str>,
             token_type: &'a str,
             expires_in: String,
             scope: &'a str,
@@ -364,7 +364,7 @@ impl BearerToken {
         let remaining = self.0.until.signed_duration_since(Utc::now());
         let serial = Serial {
             access_token: self.0.token.as_str(),
-            refresh: Some(self.0.refresh.as_str())
+            refresh_token: Some(self.0.refresh.as_str())
                 .filter(|_| self.0.refreshable()),
             token_type: "bearer",
             expires_in: remaining.num_seconds().to_string(),
@@ -392,7 +392,7 @@ mod tests {
         let mut token = serde_json::from_str::<HashMap<String, String>>(&json).unwrap();
 
         assert_eq!(token.remove("access_token"), Some("access".to_string()));
-        assert_eq!(token.remove("refresh"), Some("refresh".to_string()));
+        assert_eq!(token.remove("refresh_token"), Some("refresh".to_string()));
         assert_eq!(token.remove("scope"), Some("scope".to_string()));
         assert_eq!(token.remove("token_type"), Some("bearer".to_string()));
         assert!(token.remove("expires_in").is_some());
@@ -409,7 +409,7 @@ mod tests {
         let mut token = serde_json::from_str::<HashMap<String, String>>(&json).unwrap();
 
         assert_eq!(token.remove("access_token"), Some("access".to_string()));
-        assert_eq!(token.remove("refresh"), None);
+        assert_eq!(token.remove("refresh_token"), None);
         assert_eq!(token.remove("scope"), Some("scope".to_string()));
         assert_eq!(token.remove("token_type"), Some("bearer".to_string()));
         assert!(token.remove("expires_in").is_some());

--- a/src/code_grant/accesstoken.rs
+++ b/src/code_grant/accesstoken.rs
@@ -349,14 +349,69 @@ impl ErrorDescription {
 impl BearerToken {
     /// Convert the token into a json string, viable for being sent over a network with
     /// `application/json` encoding.
+    // FIXME: rename to `into_json` or have `&self` argument.
     pub fn to_json(self) -> String {
+        #[derive(Serialize)]
+        struct Serial<'a> {
+            access_token: &'a str,
+            #[serde(skip_serializing_if="Option::is_none")]
+            refresh: Option<&'a str>,
+            token_type: &'a str,
+            expires_in: String,
+            scope: &'a str,
+        }
+
         let remaining = self.0.until.signed_duration_since(Utc::now());
-        let kvmap: HashMap<_, _> = vec![
-            ("access_token", self.0.token),
-            ("refresh_token", self.0.refresh),
-            ("token_type", "bearer".to_string()),
-            ("expires_in", remaining.num_seconds().to_string()),
-            ("scope", self.1)].into_iter().collect();
-        serde_json::to_string(&kvmap).unwrap()
+        let serial = Serial {
+            access_token: self.0.token.as_str(),
+            refresh: Some(self.0.refresh.as_str())
+                .filter(|_| self.0.refreshable()),
+            token_type: "bearer",
+            expires_in: remaining.num_seconds().to_string(),
+            scope: self.1.as_str(),
+        };
+
+        serde_json::to_string(&serial).unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn bearer_token_encoding() {
+        let token = BearerToken(IssuedToken {
+            token: "access".into(),
+            refresh: "refresh".into(),
+            until: Utc::now(),
+        }, "scope".into());
+
+        let json = token.to_json();
+        let mut token = serde_json::from_str::<HashMap<String, String>>(&json).unwrap();
+
+        assert_eq!(token.remove("access_token"), Some("access".to_string()));
+        assert_eq!(token.remove("refresh"), Some("refresh".to_string()));
+        assert_eq!(token.remove("scope"), Some("scope".to_string()));
+        assert_eq!(token.remove("token_type"), Some("bearer".to_string()));
+        assert!(token.remove("expires_in").is_some());
+    }
+
+    #[test]
+    fn no_refresh_encoding() {
+        let token = BearerToken(IssuedToken::without_refresh(
+            "access".into(),
+            Utc::now(),
+        ), "scope".into());
+
+        let json = token.to_json();
+        let mut token = serde_json::from_str::<HashMap<String, String>>(&json).unwrap();
+
+        assert_eq!(token.remove("access_token"), Some("access".to_string()));
+        assert_eq!(token.remove("refresh"), None);
+        assert_eq!(token.remove("scope"), Some("scope".to_string()));
+        assert_eq!(token.remove("token_type"), Some("bearer".to_string()));
+        assert!(token.remove("expires_in").is_some());
     }
 }

--- a/src/code_grant/error.rs
+++ b/src/code_grant/error.rs
@@ -134,7 +134,11 @@ impl AccessTokenErrorType {
 
 /// Represents parameters of an error in an [Issuing Error Response][Issuing Error].
 ///
+/// This is used for both access token requests, and [token refresh requests] as they use the same
+/// internal error representations in the RFC as well.
+///
 /// [Issuing Error]: https://tools.ietf.org/html/rfc6749#section-5.2
+/// [token refresh requests]: https://tools.ietf.org/html/rfc6749#section-7
 #[derive(Clone, Debug)]
 pub struct AccessTokenError {
     error: AccessTokenErrorType,

--- a/src/code_grant/error.rs
+++ b/src/code_grant/error.rs
@@ -62,6 +62,7 @@ pub struct AuthorizationError {
 }
 
 impl AuthorizationError {
+    #[allow(dead_code)]
     pub(crate) fn new(error: AuthorizationErrorType) -> Self {
         AuthorizationError {
             error,

--- a/src/code_grant/error.rs
+++ b/src/code_grant/error.rs
@@ -62,6 +62,14 @@ pub struct AuthorizationError {
 }
 
 impl AuthorizationError {
+    pub(crate) fn new(error: AuthorizationErrorType) -> Self {
+        AuthorizationError {
+            error,
+            description: None,
+            uri: None,
+        }
+    }
+
     pub(crate) fn set_type(&mut self, new_type: AuthorizationErrorType) {
         self.error = new_type;
     }
@@ -147,6 +155,14 @@ pub struct AccessTokenError {
 }
 
 impl AccessTokenError {
+    pub(crate) fn new(error: AccessTokenErrorType) -> Self {
+        AccessTokenError {
+            error,
+            description: None,
+            uri: None,
+        }
+    }
+
     pub(crate) fn set_type(&mut self, new_type: AccessTokenErrorType) {
         self.error = new_type;
     }

--- a/src/code_grant/mod.rs
+++ b/src/code_grant/mod.rs
@@ -28,11 +28,8 @@
 //! [`Endpoint`]: ../endpoint/trait.Endpoint.html
 
 pub mod accesstoken;
-
 pub mod authorization;
-
-pub mod resource;
-
-pub mod extensions;
-
 pub mod error;
+pub mod extensions;
+pub mod refresh;
+pub mod resource;

--- a/src/code_grant/refresh.rs
+++ b/src/code_grant/refresh.rs
@@ -36,6 +36,11 @@ pub trait Request {
     fn extension(&self, key: &str) -> Option<Cow<str>>;
 }
 
+/// The specific endpoin trait for refreshing.
+///
+/// Each method will only be invoked exactly once when processing a correct and authorized request,
+/// and potentially less than once when the request is faulty.  These methods should be implemented
+/// by internally using `primitives`, as it is implemented in the `frontend` module.
 pub trait Endpoint {
     /// Authenticate the requesting confidential client.
     fn registrar(&self) -> &dyn Registrar;

--- a/src/code_grant/refresh.rs
+++ b/src/code_grant/refresh.rs
@@ -129,7 +129,7 @@ pub fn refresh(handler: &mut dyn Endpoint, request: &dyn Request)
     }
 
     match request.grant_type() {
-        Some(ref cow) if cow == "authorization_code" => (),
+        Some(ref cow) if cow == "refresh_token" => (),
         None => return Err(Error::invalid(AccessTokenErrorType::InvalidRequest)),
         Some(_) => return Err(Error::invalid(AccessTokenErrorType::UnsupportedGrantType)),
     };

--- a/src/code_grant/refresh.rs
+++ b/src/code_grant/refresh.rs
@@ -1,0 +1,3 @@
+//! Retrieve a refreshed access token.
+
+

--- a/src/code_grant/refresh.rs
+++ b/src/code_grant/refresh.rs
@@ -1,3 +1,82 @@
 //! Retrieve a refreshed access token.
+use std::borrow::Cow;
+use std::result::Result as StdResult;
 
+use code_grant::error::{AccessTokenError, AccessTokenErrorType};
+use primitives::issuer::{IssuedToken, Issuer};
+use primitives::grant::Grant;
+use primitives::registrar::{Registrar, RegistrarError};
 
+/// Required content of a refresh request.
+///
+/// See [Refreshing an Access Token] in the rfc.
+///
+/// [Refreshing an Access Token]: https://tools.ietf.org/html/rfc6749#section-6
+pub trait Request {
+    /// Received request might not be encoded correctly. This method gives implementors the chance
+    /// to signal that a request was received but its encoding was generally malformed. If this is
+    /// the case, then no other attribute will be queried. This method exists mainly to make
+    /// frontends straightforward by not having them handle special cases for malformed requests.
+    fn valid(&self) -> bool;
+
+    /// The refresh token with which to refresh.
+    fn refresh_token(&self) -> Option<Cow<str>>;
+
+    /// Optionally specifies the requested scope
+    fn scope(&self) -> Option<Cow<str>>;
+
+    /// Valid requests have this set to "refresh_token"
+    fn grant_type(&self) -> Option<Cow<str>>;
+
+    /// User:password of a basic authorization header.
+    fn authorization(&self) -> Option<(Cow<str>, Cow<[u8]>)>;
+
+    /// The client_id, optional parameter for public clients.
+    fn client_id(&self) -> Option<Cow<str>>;
+
+    /// Retrieve an additional parameter used in an extension
+    fn extension(&self, key: &str) -> Option<Cow<str>>;
+}
+
+pub trait Endpoint {
+    /// Authenticate the requesting confidential client.
+    fn registrar(&self) -> &dyn Registrar;
+
+    /// Recover and test the provided refresh token then issue new tokens.
+    fn issuer(&mut self) -> &mut dyn Issuer;
+}
+
+/// Represents a bearer token, optional refresh token and the associated scope for serialization.
+pub struct RefreshedToken(IssuedToken, String);
+
+/// Defines actions for the response to an access token request.
+pub enum Error {
+    /// The token did not represent a valid token.
+    Invalid(ErrorDescription),
+
+    /// The client did not properly authorize itself.
+    Unauthorized(ErrorDescription, String),
+
+    /// An underlying primitive operation did not complete successfully.
+    ///
+    /// This is expected to occur with some endpoints. See `PrimitiveError` for
+    /// more details on when this is returned.
+    Primitive,
+}
+
+/// Simple wrapper around RefreshError.
+///
+/// Enables addtional json functionality to generate a properly formatted response in the user of
+/// this module.
+pub struct ErrorDescription {
+    error: AccessTokenError,
+}
+
+type Result<T> = std::result::Result<T, Error>;
+
+/// Try to get a refreshed access token.
+pub fn refresh(handler: &mut dyn Endpoint, request: &dyn Request)
+    -> Result<RefreshedToken> 
+{
+    unimplemented!()
+}

--- a/src/code_grant/refresh.rs
+++ b/src/code_grant/refresh.rs
@@ -212,6 +212,10 @@ impl ErrorDescription {
     pub fn description(&mut self) -> &mut AccessTokenError {
         &mut self.error
     }
+
+    pub fn to_json(&self) -> String {
+        unimplemented!()
+    }
 }
 
 impl BearerToken {

--- a/src/code_grant/refresh.rs
+++ b/src/code_grant/refresh.rs
@@ -1,10 +1,10 @@
 //! Retrieve a refreshed access token.
 use std::borrow::Cow;
-use std::result::Result as StdResult;
+
+use chrono::{Duration, Utc};
 
 use code_grant::error::{AccessTokenError, AccessTokenErrorType};
-use primitives::issuer::{IssuedToken, Issuer};
-use primitives::grant::Grant;
+use primitives::issuer::{RefreshedToken, Issuer};
 use primitives::registrar::{Registrar, RegistrarError};
 
 /// Required content of a refresh request.
@@ -31,9 +31,6 @@ pub trait Request {
     /// User:password of a basic authorization header.
     fn authorization(&self) -> Option<(Cow<str>, Cow<[u8]>)>;
 
-    /// The client_id, optional parameter for public clients.
-    fn client_id(&self) -> Option<Cow<str>>;
-
     /// Retrieve an additional parameter used in an extension
     fn extension(&self, key: &str) -> Option<Cow<str>>;
 }
@@ -47,7 +44,7 @@ pub trait Endpoint {
 }
 
 /// Represents a bearer token, optional refresh token and the associated scope for serialization.
-pub struct RefreshedToken(IssuedToken, String);
+pub struct BearerToken(RefreshedToken, String);
 
 /// Defines actions for the response to an access token request.
 pub enum Error {
@@ -76,7 +73,123 @@ type Result<T> = std::result::Result<T, Error>;
 
 /// Try to get a refreshed access token.
 pub fn refresh(handler: &mut dyn Endpoint, request: &dyn Request)
-    -> Result<RefreshedToken> 
+    -> Result<BearerToken> 
 {
-    unimplemented!()
+    if !request.valid() {
+        return Err(Error::invalid(AccessTokenErrorType::InvalidRequest))
+    }
+
+    // The server MUST authenticate the client if authentication is included.
+    // ... MUST request client authentication for confidential clients.
+    //
+    // In effect, if this is `Some(_)` we should error due to wrong refresh token before we have
+    // validated that the authorization authenticates a client? But we must inspect the token to
+    // know if there is a client to validate.
+    let authorization = request.authorization();
+    let token = request.refresh_token();
+
+    // MUST validate the refresh token.
+    let grant = token.map(|token| {
+        handler
+            .issuer()
+            .recover_refresh(&token)
+            // Primitive error is ok, that's like internal server error.
+            .map_err(|()| Error::Primitive)
+    });
+
+    let grant = match grant {
+        Some(grant) => grant?,
+        None => None,
+    };
+
+    let grant_client = grant.as_ref().map(|grant| grant.client_id.clone());
+
+    // Find client to authenticate either through header or the grant data.
+    //
+    // Always use the header data if present to prevent 2-for-1 attempts against client auth and
+    // token simultaneously.
+    let (client_to_auth, passdata) = match &authorization {
+        Some((client, pass)) => (Some(client.as_ref()), Some(pass.as_ref())),
+        // ... MUST require client authentication for confidential clients.
+        //
+        // We'll see if this was confidential by trying to auth with no passdata. If that fails,
+        // then the client should have authenticated with header information.
+        None => (grant_client.as_ref().map(|client| client.as_str()), None),
+    };
+
+    if let Some(client) = client_to_auth {
+        handler
+            .registrar()
+            .check(client, passdata)
+            .map_err(|err| match err {
+                RegistrarError::PrimitiveError => Error::Primitive,
+                RegistrarError::Unspecified => Error::unauthorized("basic"),
+            })?;
+    }
+
+    match request.grant_type() {
+        Some(ref cow) if cow == "authorization_code" => (),
+        None => return Err(Error::invalid(AccessTokenErrorType::InvalidRequest)),
+        Some(_) => return Err(Error::invalid(AccessTokenErrorType::UnsupportedGrantType)),
+    };
+
+    let grant = grant
+        // ... is invalid, expired, revoked, ... (Section 5.2)
+        .ok_or_else(|| Error::invalid(AccessTokenErrorType::InvalidGrant))?;
+
+    // ... MUST ensure that the refresh token was issued to the authenticated client.
+    if let Some(client) = client_to_auth {
+        if grant.client_id.as_str() != client {
+            // ... or was issued to another client (Section 5.2)
+            return Err(Error::unauthorized("basic"))
+        }
+    }
+
+    let scope = match request.scope() {
+        // ... is invalid, unknown, malformed (Section 5.2)
+        Some(scope) => Some(scope.parse().map_err(|_| Error::invalid(AccessTokenErrorType::InvalidScope))?),
+        None => None,
+    };
+
+    let scope = match scope {
+        Some(scope) => {
+            // ... MUST NOT include any scope not originally granted.
+            if !(&scope <= &grant.scope) {
+                // ... or exceeds the scope grant (Section 5.2)
+                return Err(Error::invalid(AccessTokenErrorType::InvalidScope))
+            }
+            scope
+        },
+        // ... if omitted is treated as equal to the scope originally granted
+        None => grant.scope.clone(),
+    };
+
+    // Update the grant with the derived data.
+    let str_scope = scope.to_string();
+    let mut grant = grant;
+    grant.scope = scope;
+    grant.until = Utc::now() + Duration::hours(1);
+
+    let token = handler
+        .issuer()
+        .refresh(grant)
+        .map_err(|()| Error::Primitive)?;
+
+    Ok(BearerToken { 0: token, 1: str_scope })
+}
+
+impl Error {
+    fn invalid(kind: AccessTokenErrorType) -> Self {
+        Error::Invalid(ErrorDescription {
+            error: AccessTokenError::new(kind),
+        })
+    }
+
+    fn unauthorized(authtype: &str) -> Self {
+        Error::Unauthorized(ErrorDescription {
+                // ... authentication failed (Section 5.2)
+                error: AccessTokenError::new(AccessTokenErrorType::InvalidClient),
+            },
+            authtype.to_string())
+    }
 }

--- a/src/code_grant/refresh.rs
+++ b/src/code_grant/refresh.rs
@@ -213,8 +213,14 @@ impl ErrorDescription {
         &mut self.error
     }
 
-    pub fn to_json(&self) -> String {
-        unimplemented!()
+    /// Convert the error into a json string.
+    ///
+    /// The string may be the content of an `application/json` body for example.
+    pub fn to_json(self) -> String {
+        let asmap = self.error.into_iter()
+            .map(|(k, v)| (k.to_string(), v.into_owned()))
+            .collect::<HashMap<String, String>>();
+        serde_json::to_string(&asmap).unwrap()
     }
 }
 

--- a/src/endpoint/mod.rs
+++ b/src/endpoint/mod.rs
@@ -31,6 +31,7 @@
 mod authorization;
 mod accesstoken;
 mod error;
+mod refresh;
 mod resource;
 mod query;
 

--- a/src/endpoint/mod.rs
+++ b/src/endpoint/mod.rs
@@ -59,6 +59,7 @@ pub use primitives::registrar::PreGrant;
 pub use self::authorization::*;
 pub use self::accesstoken::*;
 pub use self::error::OAuthError;
+pub use self::refresh::RefreshFlow;
 pub use self::resource::*;
 pub use self::query::*;
 

--- a/src/endpoint/refresh.rs
+++ b/src/endpoint/refresh.rs
@@ -1,0 +1,51 @@
+use std::borrow::Cow;
+
+use code_grant::refresh::{
+    refresh,
+    Error,
+    Endpoint as RefreshEndpoint,
+    Request};
+use primitives::grant::Grant;
+
+use super::*;
+
+/// Guards resources by requiring OAuth authorization.
+pub struct RefreshFlow<E, R> where E: Endpoint<R>, R: WebRequest {
+    endpoint: WrappedRefresh<E, R>,
+}
+
+struct WrappedRefresh<E: Endpoint<R>, R: WebRequest>{
+    inner: E, 
+    r_type: PhantomData<R>,
+}
+
+struct WrappedRequest<R: WebRequest> {
+    /// Original request.
+    request: PhantomData<R>,
+
+    /// The authorization token.
+    authorization: Option<String>,
+
+    /// An error if one occurred.
+    error: Option<Option<R::Error>>,
+}
+
+impl<E, R> RefreshFlow<E, R> where E: Endpoint<R>, R: WebRequest {
+    pub fn prepare(mut endpoint: E) -> Result<Self, E::Error> {
+        if endpoint.registrar().is_none() {
+            return Err(endpoint.error(OAuthError::PrimitiveError));
+        }
+
+        if endpoint.issuer_mut().is_none() {
+            return Err(endpoint.error(OAuthError::PrimitiveError));
+        }
+
+        Ok(RefreshFlow {
+            endpoint: WrappedRefresh {
+                inner: endpoint,
+                r_type: PhantomData,
+            },
+        })
+    }
+}
+

--- a/src/endpoint/refresh.rs
+++ b/src/endpoint/refresh.rs
@@ -1,13 +1,10 @@
 use std::borrow::Cow;
+use std::marker::PhantomData;
+use std::str::from_utf8;
 
-use code_grant::refresh::{
-    refresh,
-    Error,
-    Endpoint as RefreshEndpoint,
-    Request};
-use primitives::grant::Grant;
-
-use super::*;
+use code_grant::refresh::{refresh, Error, Endpoint as RefreshEndpoint, Request};
+use primitives::{registrar::Registrar, issuer::Issuer};
+use super::{Endpoint, InnerTemplate, OAuthError, QueryParameter, WebRequest, WebResponse};
 
 /// Guards resources by requiring OAuth authorization.
 pub struct RefreshFlow<E, R> where E: Endpoint<R>, R: WebRequest {
@@ -19,16 +16,21 @@ struct WrappedRefresh<E: Endpoint<R>, R: WebRequest>{
     r_type: PhantomData<R>,
 }
 
-struct WrappedRequest<R: WebRequest> {
+struct WrappedRequest<'a, R: WebRequest + 'a> {
     /// Original request.
     request: PhantomData<R>,
 
+    /// The query in the body.
+    body: Cow<'a, dyn QueryParameter + 'static>,
+
     /// The authorization token.
-    authorization: Option<String>,
+    authorization: Option<Authorization>,
 
     /// An error if one occurred.
     error: Option<Option<R::Error>>,
 }
+
+struct Authorization(String, Vec<u8>);
 
 impl<E, R> RefreshFlow<E, R> where E: Endpoint<R>, R: WebRequest {
     pub fn prepare(mut endpoint: E) -> Result<Self, E::Error> {
@@ -47,5 +49,153 @@ impl<E, R> RefreshFlow<E, R> where E: Endpoint<R>, R: WebRequest {
             },
         })
     }
+
+    pub fn execute(&mut self, mut request: R) -> Result<R::Response, E::Error> {
+        let refreshed = refresh(
+            &mut self.endpoint,
+            &WrappedRequest::new(&mut request));
+
+        let token = match refreshed {
+            Err(error) => return token_error(&mut self.endpoint.inner, &mut request, error),
+            Ok(token) => token,
+        };
+
+        let mut response = self.endpoint.inner.response(&mut request, InnerTemplate::Ok.into())?;
+        response.body_json(&token.to_json())
+            .map_err(|err| self.endpoint.inner.web_error(err))?;
+        Ok(response)
+    }
 }
 
+fn token_error<E: Endpoint<R>, R: WebRequest>(endpoint: &mut E, request: &mut R, error: Error)
+    -> Result<R::Response, E::Error> 
+{
+    Ok(match error {
+        Error::Invalid(mut json) => {
+            let mut response = endpoint.response(request, InnerTemplate::BadRequest {
+                access_token_error: Some(json.description()),
+            }.into())?;
+            response.client_error()
+                .map_err(|err| endpoint.web_error(err))?;
+            response.body_json(&json.to_json())
+                .map_err(|err| endpoint.web_error(err))?;
+            response
+        },
+        Error::Unauthorized(mut json, scheme) =>{
+            let mut response = endpoint.response(request, InnerTemplate::Unauthorized {
+                error: None,
+                access_token_error: Some(json.description()),
+            }.into())?;
+            response.unauthorized(&scheme)
+                .map_err(|err| endpoint.web_error(err))?;
+            response.body_json(&json.to_json())
+                .map_err(|err| endpoint.web_error(err))?;
+            response
+        },
+        Error::Primitive => {
+            // FIXME: give the context for restoration.
+            return Err(endpoint.error(OAuthError::PrimitiveError))
+        },
+    })
+}
+
+impl<'a, R: WebRequest + 'a> WrappedRequest<'a, R> {
+    pub fn new(request: &'a mut R) -> Self {
+        Self::new_or_fail(request)
+            .unwrap_or_else(Self::from_err)
+    }
+
+    fn new_or_fail(request: &'a mut R) -> Result<Self, Option<R::Error>> {
+        // If there is a header, it must parse correctly.
+        let authorization = match request.authheader() {
+            Err(err) => return Err(Some(err)),
+            Ok(Some(header)) => Self::parse_header(header).map(Some)?,
+            Ok(None) => None,
+        };
+
+        Ok(WrappedRequest {
+            request: PhantomData,
+            body: request.urlbody()?,
+            authorization,
+            error: None,
+        })
+    }
+
+    fn from_err(err: Option<R::Error>) -> Self {
+        WrappedRequest {
+            request: PhantomData,
+            body: Cow::Owned(Default::default()),
+            authorization: None,
+            error: Some(err),
+        }
+    }
+
+    fn parse_header(header: Cow<str>) -> Result<Authorization, Option<R::Error>> {
+        let authorization = {
+            if !header.starts_with("Basic ") {
+                return Err(None)
+            }
+
+            let combined = match base64::decode(&header[6..]) {
+                Err(_) => return Err(None),
+                Ok(vec) => vec,
+            };
+
+            let mut split = combined.splitn(2, |&c| c == b':');
+            let client_bin = match split.next() {
+                None => return Err(None),
+                Some(client) => client,
+            };
+            let passwd = match split.next() {
+                None => return Err(None),
+                Some(passwd64) => passwd64,
+            };
+
+            let client = match from_utf8(client_bin) {
+                Err(_) => return Err(None),
+                Ok(client) => client,
+            };
+
+            Authorization(client.to_string(), passwd.to_vec())
+        };
+
+        Ok(authorization)
+    }
+}
+
+impl<E: Endpoint<R>, R: WebRequest> RefreshEndpoint for WrappedRefresh<E, R> {
+    fn registrar(&self) -> &dyn Registrar {
+        self.inner.registrar().unwrap()
+    }
+
+    fn issuer(&mut self) -> &mut dyn Issuer {
+        self.inner.issuer_mut().unwrap()
+    }
+}
+
+impl<'a, R: WebRequest> Request for WrappedRequest<'a, R> {
+    fn valid(&self) -> bool {
+        self.error.is_none()
+    }
+
+    fn refresh_token(&self) -> Option<Cow<str>> {
+        self.body.unique_value("refresh_token")
+    }
+
+    fn authorization(&self) -> Option<(Cow<str>, Cow<[u8]>)> {
+        self.authorization.as_ref()
+            .map(|auth| (auth.0.as_str().into(), auth.1.as_slice().into()))
+    }
+
+    fn scope(&self) -> Option<Cow<str>> {
+        self.body.unique_value("scope")
+    }
+
+    fn grant_type(&self) -> Option<Cow<str>> {
+        self.body.unique_value("grant_type")
+    }
+
+    fn extension(&self, key: &str) -> Option<Cow<str>> {
+        self.body.unique_value(key)
+    }
+}

--- a/src/endpoint/tests/access_token.rs
+++ b/src/endpoint/tests/access_token.rs
@@ -1,4 +1,4 @@
-use primitives::authorizer::AuthMap;
+use primitives::authorizer::{AuthMap, Authorizer};
 use primitives::issuer::TokenMap;
 use primitives::grant::{Grant, Extensions};
 use primitives::registrar::{Client, ClientMap};
@@ -25,7 +25,6 @@ struct AccessTokenSetup {
 
 impl AccessTokenSetup {
     fn private_client() -> Self {
-        use primitives::authorizer::Authorizer;
         let mut registrar = ClientMap::new();
         let mut authorizer = AuthMap::new(TestGenerator("AuthToken".to_string()));
         let issuer = TokenMap::new(TestGenerator("AccessToken".to_string()));
@@ -60,7 +59,6 @@ impl AccessTokenSetup {
     }
 
     fn public_client() -> Self {
-        use primitives::authorizer::Authorizer;
         let mut registrar = ClientMap::new();
         let mut authorizer = AuthMap::new(TestGenerator("AuthToken".to_string()));
         let issuer = TokenMap::new(TestGenerator("AccessToken".to_string()));

--- a/src/endpoint/tests/mod.rs
+++ b/src/endpoint/tests/mod.rs
@@ -209,14 +209,8 @@ pub mod defaults {
     pub const EXAMPLE_SCOPE: &str = "example default";
 }
 
-/// Test the authorization code flow.
 mod authorization;
-
-/// Test the access token flow.
 mod access_token;
-
-/// Test the resource flow.
 mod resource;
-
-/// Test functionality of pkce.
+mod refresh;
 mod pkce;

--- a/src/endpoint/tests/refresh.rs
+++ b/src/endpoint/tests/refresh.rs
@@ -1,0 +1,160 @@
+use primitives::issuer::{Issuer, IssuedToken, RefreshedToken, TokenMap};
+use primitives::generator::RandomGenerator;
+use primitives::grant::{Grant, Extensions};
+use primitives::registrar::{Client, ClientMap};
+
+use std::collections::HashMap;
+
+use base64;
+use chrono::{Utc, Duration};
+use serde_json;
+
+use super::{Body, CraftedRequest, Status, ToSingleValueQuery};
+use super::defaults::*;
+use frontends::simple::endpoint::{refresh_flow, resource_flow};
+
+struct AccessTokenSetup {
+    registrar: ClientMap,
+    issuer: TokenMap<RandomGenerator>,
+    issued: IssuedToken,
+    basic_authorization: String,
+}
+
+impl AccessTokenSetup {
+    const SMALLER_SCOPE: &'static str = "example";
+    const WIDER_SCOPE: &'static str = "example default more";
+    const DISJUNCT_SCOPE: &'static str = "example more";
+
+    fn private_client() -> Self {
+        let mut registrar = ClientMap::new();
+        let mut issuer = TokenMap::new(RandomGenerator::new(16));
+
+        let client = Client::confidential(EXAMPLE_CLIENT_ID,
+            EXAMPLE_REDIRECT_URI.parse().unwrap(),
+            EXAMPLE_SCOPE.parse().unwrap(),
+            EXAMPLE_PASSPHRASE.as_bytes());
+
+        let grant = Grant {
+            client_id: EXAMPLE_CLIENT_ID.to_string(),
+            owner_id: EXAMPLE_OWNER_ID.to_string(),
+            redirect_uri: EXAMPLE_REDIRECT_URI.parse().unwrap(),
+            scope: EXAMPLE_SCOPE.parse().unwrap(),
+            until: Utc::now() + Duration::hours(1),
+            extensions: Extensions::new(),
+        };
+
+        registrar.register_client(client);
+        let issued = issuer.issue(grant).unwrap();
+        assert!(!issued.refresh.is_empty());
+
+        let basic_authorization = base64::encode(&format!("{}:{}",
+            EXAMPLE_CLIENT_ID, EXAMPLE_PASSPHRASE));
+        let basic_authorization = format!("Basic {}", basic_authorization);
+
+        AccessTokenSetup {
+            registrar,
+            issuer,
+            issued,
+            basic_authorization,
+        }
+    }
+
+    fn public_client() -> Self {
+        let mut registrar = ClientMap::new();
+        let mut issuer = TokenMap::new(RandomGenerator::new(16));
+
+        let client = Client::public(EXAMPLE_CLIENT_ID,
+            EXAMPLE_REDIRECT_URI.parse().unwrap(),
+            EXAMPLE_SCOPE.parse().unwrap());
+
+        let grant = Grant {
+            client_id: EXAMPLE_CLIENT_ID.to_string(),
+            owner_id: EXAMPLE_OWNER_ID.to_string(),
+            redirect_uri: EXAMPLE_REDIRECT_URI.parse().unwrap(),
+            scope: EXAMPLE_SCOPE.parse().unwrap(),
+            until: Utc::now() + Duration::hours(1),
+            extensions: Extensions::new(),
+        };
+
+        registrar.register_client(client);
+        let issued = issuer.issue(grant).unwrap();
+        assert!(!issued.refresh.is_empty());
+
+        let basic_authorization = "DO_NOT_USE".into();
+
+        AccessTokenSetup {
+            registrar,
+            issuer,
+            issued,
+            basic_authorization,
+        }
+    }
+
+    fn test_success(&mut self, request: CraftedRequest) -> RefreshedToken {
+        let response = refresh_flow(&self.registrar, &mut self.issuer)
+            .execute(request)
+            .expect("Expected non-error reponse");
+        assert_eq!(response.status, Status::Ok);
+        let body = match response.body {
+            Some(Body::Json(body)) => body,
+            _ => panic!("Expect json body"),
+        };
+        let mut body: HashMap<String, String> = serde_json::from_str(&body)
+            .expect("Expected valid json body");
+        let duration: i64 = body.remove("expires_in")
+            .unwrap()
+            .parse()
+            .unwrap();
+        RefreshedToken {
+            token: body.remove("access_token").expect("Expected a token"),
+            refresh: body.remove("refresh_token"),
+            until: Utc::now() + Duration::seconds(duration),
+        }
+    }
+
+    fn access_resource(&mut self, token: String) {
+        let request = CraftedRequest {
+            query: None,
+            urlbody: None,
+            auth: Some(format!("Bearer {}", token)),
+        };
+
+        resource_flow(&mut self.issuer, &[EXAMPLE_SCOPE.parse().unwrap()])
+            .execute(request)
+            .expect("Expected access allowed");
+    }
+}
+
+#[test]
+fn access_valid_public() {
+    let mut setup = AccessTokenSetup::public_client();
+
+    let valid_public = CraftedRequest {
+        query: None,
+        urlbody: Some(vec![
+                ("grant_type", "refresh_token"),
+                ("refresh_token", &setup.issued.refresh)]
+            .iter().to_single_value_query()),
+        auth: None,
+    };
+
+    let new_token = setup.test_success(valid_public);
+    setup.access_resource(new_token.token);
+}
+
+#[test]
+fn access_valid_private() {
+    let mut setup = AccessTokenSetup::private_client();
+
+    let valid_public = CraftedRequest {
+        query: None,
+        urlbody: Some(vec![
+                ("grant_type", "refresh_token"),
+                ("refresh_token", &setup.issued.refresh)]
+            .iter().to_single_value_query()),
+        auth: Some(setup.basic_authorization.clone()),
+    };
+
+    let new_token = setup.test_success(valid_public);
+    setup.access_resource(new_token.token);
+}

--- a/src/frontends/actix/message/issuer.rs
+++ b/src/frontends/actix/message/issuer.rs
@@ -1,4 +1,4 @@
-use primitives::issuer::{Issuer, IssuedToken};
+use primitives::issuer::{Issuer, IssuedToken, RefreshedToken};
 use primitives::grant::Grant;
 
 use super::super::actix::{Handler, Message};
@@ -12,6 +12,19 @@ pub struct Issue {
 
 impl Message for Issue {
     type Result = Result<IssuedToken, ()>;
+}
+
+/// Issue a renewed bearer token.
+pub struct Refresh {
+    /// The refresh token with which to issue a refreshed bearer token.
+    pub token: String,
+
+    /// The grant defining client, scope and timeframe of the token.
+    pub grant: Grant,
+}
+
+impl Message for Refresh {
+    type Result = Result<RefreshedToken, ()>;
 }
 
 /// Try to find the grant of a specific token.
@@ -41,6 +54,14 @@ impl<I: Issuer + 'static> Handler<Issue> for AsActor<I> {
 
     fn handle(&mut self, msg: Issue, _: &mut Self::Context) -> Self::Result {
         self.0.issue(msg.grant)
+    }
+}
+
+impl<I: Issuer + 'static> Handler<Refresh> for AsActor<I> {
+    type Result = Result<RefreshedToken, ()>;
+
+    fn handle(&mut self, msg: Refresh, _: &mut Self::Context) -> Self::Result {
+        self.0.refresh(&msg.token, msg.grant)
     }
 }
 

--- a/src/frontends/actix/message/mod.rs
+++ b/src/frontends/actix/message/mod.rs
@@ -15,7 +15,7 @@ use primitives::grant::Grant;
 use endpoint::WebRequest;
 
 pub use self::authorizer::{Authorize, Extract};
-pub use self::issuer::{Issue, RecoverToken, RecoverRefresh};
+pub use self::issuer::{Issue, RecoverToken, RecoverRefresh, Refresh};
 pub use self::registrar::{BoundRedirect, Check, Negotiate};
 
 /// A request for an authorization code from an endpoint actor.

--- a/src/frontends/actix/mod.rs
+++ b/src/frontends/actix/mod.rs
@@ -27,7 +27,7 @@ pub use self::request::OAuthFuture;
 pub use self::request::OAuthRequest;
 pub use self::request::OAuthResponse;
 
-pub use self::future_endpoint::{ResourceProtection, access_token, authorization, resource};
+pub use self::future_endpoint::{ResourceProtection, access_token, authorization, refresh, resource};
 
 /// Bundles all oauth related methods under a single type.
 pub trait OAuth {

--- a/src/frontends/simple/endpoint.rs
+++ b/src/frontends/simple/endpoint.rs
@@ -362,7 +362,7 @@ impl<R, A, I, O, C, L> Generic<R, A, I, O, C, L> {
         }
     }
 
-    /// Create an authorizer flow.
+    /// Create an authorization flow.
     ///
     /// Opposed to `AuthorizationFlow::prepare` this statically ensures that the construction
     /// succeeds.
@@ -395,10 +395,25 @@ impl<R, A, I, O, C, L> Generic<R, A, I, O, C, L> {
         }
     }
 
+    /// Create a token refresh flow.
+    ///
+    /// Opposed to `RefreshFlow::prepare` this statically ensures that the construction succeeds.
+    pub fn to_refresh<W: WebRequest>(self) -> RefreshFlow<Self, W>
+    where
+        Self: Endpoint<W>,
+        R: Registrar,
+        I: Issuer,
+    {
+        match RefreshFlow::prepare(self) {
+            Ok(flow) => flow,
+            Err(_) => unreachable!(),
+        }
+    }
+
+
     /// Create a resource access flow.
     ///
-    /// Opposed to `ResourceFlow::prepare` this statically ensures that the construction
-    /// succeeds.
+    /// Opposed to `ResourceFlow::prepare` this statically ensures that the construction succeeds.
     pub fn to_resource<W: WebRequest>(self) -> ResourceFlow<Self, W>
     where
         Self: Endpoint<W>,

--- a/src/frontends/simple/endpoint.rs
+++ b/src/frontends/simple/endpoint.rs
@@ -319,6 +319,14 @@ pub fn resource_flow<'a, W>(issuer: &'a mut dyn Issuer, scopes: &'a [Scope])
     }
 }
 
+/// Create an ad-hoc refresh flow.
+///
+/// Since all necessary primitives are expected in the function syntax, this is guaranteed to never
+/// fail or panic, compared to preparing one with `ResourceFlow`. 
+///
+/// But this is not as versatile and extensible, so it should be used with care.  The fact that it
+/// only takes references is a conscious choice to maintain forwards portability while encouraging
+/// the transition to custom `Endpoint` implementations instead.
 pub fn refresh_flow<'a, W>(registrar: &'a dyn Registrar, issuer: &'a mut dyn Issuer)
     -> RefreshFlow<Refresh<'a>, W> where W: WebRequest, W::Response: Default
 {

--- a/src/primitives/issuer.rs
+++ b/src/primitives/issuer.rs
@@ -51,6 +51,7 @@ pub struct IssuedToken {
     pub until: Time,
 }
 
+/// Refresh token information returned to a client.
 #[derive(Clone, Debug)]
 pub struct RefreshedToken {
     /// The bearer token.

--- a/src/primitives/issuer.rs
+++ b/src/primitives/issuer.rs
@@ -23,6 +23,11 @@ pub trait Issuer {
     /// Create a token authorizing the request parameters
     fn issue(&mut self, Grant) -> Result<IssuedToken, ()>;
 
+    /// Refresh a token.
+    fn refresh(&mut self, Grant) -> Result<RefreshedToken, ()> {
+        Err(())
+    }
+
     /// Get the values corresponding to a bearer token
     fn recover_token<'a>(&'a self, &'a str) -> Result<Option<Grant>, ()>;
 
@@ -38,6 +43,23 @@ pub struct IssuedToken {
 
     /// The refresh token
     pub refresh: String,
+
+    /// Expiration timestamp (Utc).
+    ///
+    /// Technically, a time to live is expected in the response but this will be transformed later.
+    /// In a direct backend access situation, this enables high precision timestamps.
+    pub until: Time,
+}
+
+#[derive(Clone, Debug)]
+pub struct RefreshedToken {
+    /// The bearer token.
+    pub token: String,
+
+    /// The new refresh token.
+    ///
+    /// If this is set, the old refresh token has been invalidated.
+    pub refresh: Option<String>,
 
     /// Expiration timestamp (Utc).
     ///

--- a/src/primitives/issuer.rs
+++ b/src/primitives/issuer.rs
@@ -178,9 +178,16 @@ impl IssuedToken {
     ///
     /// struct MyIssuer;
     ///
+    /// impl MyIssuer {
+    ///     fn access_token(&mut self, grant: &Grant) -> String {
+    ///         // .. your implementation
+    /// #       unimplemented!()
+    ///     }
+    /// }
+    ///
     /// impl Issuer for MyIssuer {
     ///     fn issue(&mut self, mut grant: Grant) -> Result<IssuedToken, ()> {
-    ///         let access = self.access_token(&grant);
+    ///         let token = self.access_token(&grant);
     ///         Ok(IssuedToken::without_refresh(token, grant.until))
     ///     }
     ///     // …
@@ -517,6 +524,17 @@ pub mod tests {
     use primitives::generator::RandomGenerator;
     use chrono::{Duration, Utc};
 
+    fn grant_template() -> Grant {
+        Grant {
+            client_id: "Client".to_string(),
+            owner_id: "Owner".to_string(),
+            redirect_uri: "https://example.com".parse().unwrap(),
+            scope: "default".parse().unwrap(),
+            until: Utc::now() + Duration::hours(1),
+            extensions: Extensions::new(),
+        }
+    }
+
     /// Tests the simplest invariants that should be upheld by all authorizers.
     ///
     /// This create a token, without any extensions, an lets the issuer generate a issued token.
@@ -525,14 +543,7 @@ pub mod tests {
     ///
     /// Custom implementations may want to import and use this in their own tests.
     pub fn simple_test_suite(issuer: &mut dyn Issuer) {
-        let request = Grant {
-            client_id: "Client".to_string(),
-            owner_id: "Owner".to_string(),
-            redirect_uri: "https://example.com".parse().unwrap(),
-            scope: "default".parse().unwrap(),
-            until: Utc::now() + Duration::hours(1),
-            extensions: Extensions::new(),
-        };
+        let request = grant_template();
 
         let issued = issuer.issue(request.clone())
             .expect("Issuing failed");
@@ -556,13 +567,34 @@ pub mod tests {
     #[test]
     fn signer_test_suite() {
         let mut signer = TokenSigner::ephemeral();
+        // Refresh tokens must be unique if generated. If they are not even generated, they are
+        // obviously not unique.
+        signer.generate_refresh_tokens(true);
         simple_test_suite(&mut signer);
+    }
+
+    #[test]
+    fn signer_no_default_refresh() {
+        let mut signer = TokenSigner::ephemeral();
+        let issued = signer.issue(grant_template());
+
+        let token = issued.expect("Issuing without refresh token failed");
+        assert!(!token.refreshable());
     }
 
     #[test]
     fn random_test_suite() {
         let mut token_map = TokenMap::new(RandomGenerator::new(16));
         simple_test_suite(&mut token_map);
+    }
+
+    #[test]
+    fn random_has_refresh() {
+        let mut token_map = TokenMap::new(RandomGenerator::new(16));
+        let issued = token_map.issue(grant_template());
+
+        let token = issued.expect("Issuing without refresh token failed");
+        assert!(token.refreshable());
     }
 
     #[test]


### PR DESCRIPTION
Adds a new flow: Refreshing access tokens with a dedicated refresh token.

 - [x] This change has tests
 - [x] This change has documentation
