### PR TITLE
Next ring versions

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -33,6 +33,12 @@ nightly_task:
   test_script: cargo test -p "$CRATE"
   before_cache_script: rm -rf $CARGO_HOME/registry/index
 
+ring_task:
+  container:
+    image: rust:latest
+  ring_013_script: pushd tests/ring-0.13 && cargo build -v && popd
+  ring_014_script: pushd tests/ring-0.14 && cargo build -v && popd
+
 release_task:
   only_if: $CIRRUS_BRANCH =~ 'release.*'
   container:

--- a/oxide-auth/Cargo.toml
+++ b/oxide-auth/Cargo.toml
@@ -20,7 +20,7 @@ chrono = "0.4.2"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-ring = "0.13"
+ring = ">=0.13,<0.15"
 rmp-serde = "^0.13"
 url = "1.7"
 

--- a/oxide-auth/src/primitives/authorizer.rs
+++ b/oxide-auth/src/primitives/authorizer.rs
@@ -116,7 +116,7 @@ pub mod tests {
     use super::*;
     use chrono::Utc;
     use primitives::grant::Extensions;
-    use primitives::generator::{Assertion, RandomGenerator};
+    use primitives::generator::{Assertion, AssertionKind, RandomGenerator};
 
     /// Tests some invariants that should be upheld by all authorizers.
     ///
@@ -160,12 +160,10 @@ pub mod tests {
 
     #[test]
     fn signing_test_suite() {
-        use ring::hmac::SigningKey;
-        use ring::digest::SHA256;
-
-        let assertion_token_instance = Assertion::new(
-            SigningKey::new(&SHA256, b"7EGgy8zManReq9l/ez0AyYE+xPpcTbssgW+8gBnIv3s="));
-        let mut storage = AuthMap::new(assertion_token_instance);
+        let assertion = Assertion::new(
+            AssertionKind::HmacSha256, 
+            b"7EGgy8zManReq9l/ez0AyYE+xPpcTbssgW+8gBnIv3s=");
+        let mut storage = AuthMap::new(assertion);
         simple_test_suite(&mut storage);
     }
 

--- a/oxide-auth/src/primitives/issuer.rs
+++ b/oxide-auth/src/primitives/issuer.rs
@@ -305,10 +305,10 @@ impl TokenSigner {
     ///
     /// Security notice: Never use a password alone to construct the signing key. Instead, generate
     /// a new key using a utility such as `openssl rand` that you then store away securely.
-    pub fn new<S: Into<Assertion>>(secret: S) -> TokenSigner {
+    pub fn new(secret: Assertion) -> TokenSigner {
         TokenSigner { 
             duration: None,
-            signer: secret.into(),
+            signer: secret,
             counter: AtomicUsize::new(0),
             have_refresh: false,
         }
@@ -318,17 +318,7 @@ impl TokenSigner {
     ///
     /// Useful for rapid prototyping where tokens need not be stored in a persistent database and
     /// can be invalidated at any time. This interface is provided with simplicity in mind, using
-    /// the default system random generator (`ring::rand::SystemRandom`). If you want an ephemeral
-    /// key but more customization, adapt the implementation.
-    ///
-    /// ```
-    /// # use oxide_auth::primitives::issuer::TokenSigner;
-    /// TokenSigner::new(
-    ///     ring::hmac::SigningKey::generate(
-    ///         &ring::digest::SHA256, 
-    ///         &mut ring::rand::SystemRandom::new())
-    ///     .unwrap());
-    /// ```
+    /// the default system random generator (`ring::rand::SystemRandom`).
     pub fn ephemeral() -> TokenSigner {
         TokenSigner::new(Assertion::ephemeral())
     }

--- a/tests/ring-0.13/.gitignore
+++ b/tests/ring-0.13/.gitignore
@@ -1,0 +1,1 @@
+Cargo.lock

--- a/tests/ring-0.13/Cargo.toml
+++ b/tests/ring-0.13/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "oxide-auth-ring-0-13"
+version = "0.1.0"
+authors = ["Andreas Molzer <andreas.molzer@gmx.de>"]
+edition = "2018"
+publish = false
+
+[workspace]
+members = ["."]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[dependencies]
+oxide-auth = { path = "../../oxide-auth" }
+ring = "0.13"

--- a/tests/ring-0.13/src/lib.rs
+++ b/tests/ring-0.13/src/lib.rs
@@ -1,0 +1,7 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/tests/ring-0.14/.gitignore
+++ b/tests/ring-0.14/.gitignore
@@ -1,0 +1,1 @@
+Cargo.lock

--- a/tests/ring-0.14/Cargo.toml
+++ b/tests/ring-0.14/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "oxide-auth-ring-0-14"
+version = "0.1.0"
+authors = ["Andreas Molzer <andreas.molzer@gmx.de>"]
+edition = "2018"
+publish = false
+
+[workspace]
+members = ["."]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[dependencies]
+oxide-auth = { path = "../../oxide-auth" }
+ring = "0.14"

--- a/tests/ring-0.14/src/lib.rs
+++ b/tests/ring-0.14/src/lib.rs
@@ -1,0 +1,7 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}


### PR DESCRIPTION
This fixes `oxide-auth` being incompatible with `ring = 0.14`. Note that this is a bit hacky and there should be a better solution when/if the version disparity gets even greater in the future. In the meantime most web frameworks use the same `cookies` crate which only has `0.13` and `0.14` in relevant versions and is reasonably stable.

Removes the pulic dependency on `ring` to allow these changes in the future.

- [x] This change has tests

[Contributing]: CONTRIBUTING.md
