### PR TITLE
Optional refresh

### DIFF
--- a/oxide-auth/src/code_grant/accesstoken.rs
+++ b/oxide-auth/src/code_grant/accesstoken.rs
@@ -364,8 +364,7 @@ impl BearerToken {
         let remaining = self.0.until.signed_duration_since(Utc::now());
         let serial = Serial {
             access_token: self.0.token.as_str(),
-            refresh_token: Some(self.0.refresh.as_str())
-                .filter(|_| self.0.refreshable()),
+            refresh_token: self.0.refresh.as_ref().map(String::as_str),
             token_type: "bearer",
             expires_in: remaining.num_seconds().to_string(),
             scope: self.1.as_str(),
@@ -384,7 +383,7 @@ mod tests {
     fn bearer_token_encoding() {
         let token = BearerToken(IssuedToken {
             token: "access".into(),
-            refresh: "refresh".into(),
+            refresh: Some("refresh".into()),
             until: Utc::now(),
         }, "scope".into());
 

--- a/oxide-auth/src/primitives/issuer.rs
+++ b/oxide-auth/src/primitives/issuer.rs
@@ -163,12 +163,11 @@ impl Token {
 impl IssuedToken {
     /// Construct a token that can not be refreshed.
     ///
-    /// Use this constructor for custom issuers that can not revoke their tokens. Since refresh
-    /// tokens are both long-lived and more powerful than their access token counterparts, it is
-    /// more dangerous to have an unrevokable refresh token. This is currently semantically
-    /// equivalent to an empty refresh token but may change in a future iteration of the interface.
-    /// While the member attributes may change, this method will not change as quickly and thus
-    /// offers some additional compatibility.
+    /// This is essential for issuers that can not revoke their tokens. Since refresh tokens are
+    /// both long-lived and more powerful than their access token counterparts, it is more
+    /// dangerous to have an unrevokable refresh token.
+    ///
+    /// This is only a shorthand for initializing the `IssuedToken` with `None` for `refresh`.
     ///
     /// ```
     /// # use oxide_auth::primitives::issuer::RefreshedToken;
@@ -204,6 +203,8 @@ impl IssuedToken {
     }
 
     /// Determine if the access token can be refreshed.
+    ///
+    /// This returns `false` if `refresh` is `None` and `true` otherwise.
     pub fn refreshable(&self) -> bool {
         self.refresh.is_some()
     }

--- a/oxide-auth/src/primitives/issuer.rs
+++ b/oxide-auth/src/primitives/issuer.rs
@@ -549,7 +549,7 @@ pub mod tests {
             .expect("Issuer failed during recover")
             .expect("Issued token appears to be invalid");
 
-        assert_ne!(Some(issued.token), issued.refresh);
+        assert_ne!(Some(&issued.token), issued.refresh.as_ref());
         assert_eq!(from_token.client_id, "Client");
         assert_eq!(from_token.owner_id, "Owner");
         assert!(Utc::now() < from_token.until);
@@ -557,9 +557,9 @@ pub mod tests {
         let issued_2 = issuer.issue(request)
             .expect("Issuing failed");
         assert_ne!(issued.token, issued_2.token);
-        assert_ne!(Some(issued.token), issued_2.refresh);
+        assert_ne!(Some(&issued.token), issued_2.refresh.as_ref());
         assert_ne!(issued.refresh, issued_2.refresh);
-        assert_ne!(issued.refresh, Some(issued_2.token));
+        assert_ne!(issued.refresh.as_ref(), Some(&issued_2.token));
     }
 
     #[test]


### PR DESCRIPTION
This updates the type of the (fairly old) `refresh` attribute of `IssuedToken` to align with its semantics of being optional. This was previously overloaded by accepting an empty token for issuers that did not want to provide a refresh tokne.

 - [x] This change has tests (remove for doc only)
 - [x] This change has documentation
