### PR TITLE
Fix Endpoint impl for ErrorInto with extension

### DIFF
--- a/oxide-auth/src/frontends/simple/endpoint.rs
+++ b/oxide-auth/src/frontends/simple/endpoint.rs
@@ -13,7 +13,7 @@ use primitives::registrar::Registrar;
 use primitives::scope::Scope;
 
 use endpoint::{AccessTokenFlow, AuthorizationFlow, ResourceFlow, RefreshFlow};
-use endpoint::{Endpoint, OAuthError, PreGrant, Template, Scopes};
+use endpoint::{Endpoint, Extension, OAuthError, PreGrant, Template, Scopes};
 use endpoint::{OwnerConsent, OwnerSolicitor};
 use endpoint::WebRequest;
 
@@ -509,6 +509,10 @@ where
 
     fn web_error(&mut self, err: W::Error) -> Self::Error {
         self.0.web_error(err).into()
+    }
+
+    fn extension(&mut self) -> Option<&mut dyn Extension> {
+        self.0.extension()
     }
 }
 


### PR DESCRIPTION
This fixes the Endpoint impl for ErrorInto, when used with an extension.

 - [x] I have read the [contribution guidelines][Contributing]
 - [ ] This change has tests (remove for doc only)
 - [ ] This change has documentation
 - [x] Corresponds to issue (#74)

[Contributing]: CONTRIBUTING.md
