### PR TITLE
Set the visibility of OAuthResponse fields to pub

### DIFF
--- a/oxide-auth-actix/src/lib.rs
+++ b/oxide-auth-actix/src/lib.rs
@@ -119,6 +119,18 @@ pub struct OAuthRequest {
     body: Option<NormalizedParameter>,
 }
 
+impl OAuthResponse {
+    /// Get the headers from `OAuthResponse`
+    pub fn get_headers(&self) -> HeaderMap {
+        self.headers.clone()
+    }
+
+    /// Get the body from `OAuthResponse`
+    pub fn get_body(&self) -> Option<String> {
+        self.body.clone()
+    }
+}
+
 /// Type implementing `WebRequest` as well as `FromRequest` for use in guarding resources
 ///
 /// This is useful over [OAuthRequest] since [OAuthResource] doesn't consume the body of the

--- a/oxide-auth-actix/src/lib.rs
+++ b/oxide-auth-actix/src/lib.rs
@@ -130,9 +130,12 @@ pub struct OAuthResource {
 #[derive(Clone, Debug)]
 /// Type implementing `WebResponse` and `Responder` for use in route handlers
 pub struct OAuthResponse {
-    status: StatusCode,
-    headers: HeaderMap,
-    body: Option<String>,
+    /// HTTP status code
+    pub status: StatusCode,
+    /// Set of HTTP headers
+    pub headers: HeaderMap,
+    /// The body of the response
+    pub body: Option<String>,
 }
 
 #[derive(Debug)]

--- a/oxide-auth-actix/src/lib.rs
+++ b/oxide-auth-actix/src/lib.rs
@@ -130,12 +130,9 @@ pub struct OAuthResource {
 #[derive(Clone, Debug)]
 /// Type implementing `WebResponse` and `Responder` for use in route handlers
 pub struct OAuthResponse {
-    /// HTTP status code
-    pub status: StatusCode,
-    /// Set of HTTP headers
-    pub headers: HeaderMap,
-    /// The body of the response
-    pub body: Option<String>,
+    status: StatusCode,
+    headers: HeaderMap,
+    body: Option<String>,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
This changes/fixes/improves &#8230;

 - [x] I have read the [contribution guidelines][Contributing]
 - [ ] This change has tests (remove for doc only)
 - [ ] This change has documentation
 - [ ] Corresponds to issue (number)

I changed the visibility of OAuthResponse fields to `pub` because there was no way to access `OAuthResponse` response header or response body from outside.

By the way, I want to do the following things.

1. At the time of `POST /authorize`, keep the information that linked the issued authorization code and the information of the authenticated user as HashMap.
2. At the time of subsequent `POST /token`, the user at the time of authentication is specified from the authorization code specified in the request body using the HashMap described above, and the issued access token is associated with the user at the time of authentication as another HashMap.
3. After that, acquire the user information at the time of authentication from the access token at the time of request as needed and use it.