### PR TITLE
Return expires_in in access token response as a number

### DIFF
--- a/examples/support/client.rs
+++ b/examples/support/client.rs
@@ -2,6 +2,7 @@ extern crate reqwest;
 extern crate serde;
 extern crate serde_json;
 
+use serde::*;
 use std::fmt;
 use std::collections::HashMap;
 use std::io::Read;
@@ -59,7 +60,26 @@ pub enum Error {
 struct State {
     pub token: Option<String>,
     pub refresh: Option<String>,
-    pub until: Option<String>,
+    pub until: Option<i64>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct TokenMap {
+    token_type: String,
+
+    scope: String,
+
+    #[serde(skip_serializing_if="Option::is_none")]
+    access_token: Option<String>,
+
+    #[serde(skip_serializing_if="Option::is_none")]
+    refresh_token: Option<String>,
+
+    #[serde(skip_serializing_if="Option::is_none")]
+    expires_in: Option<i64>,
+
+    #[serde(skip_serializing_if="Option::is_none")]
+    error: Option<String>,
 }
 
 impl Client {
@@ -88,16 +108,16 @@ impl Client {
         let token_response = client
             .execute(access_token_request)
             .map_err(|_| Error::AuthorizationFailed)?;
-        let mut token_map = parse_token_response(token_response)?;
+        let mut token_map: TokenMap = parse_token_response(token_response)?;
 
-        if let Some(err) = token_map.remove("error") {
+        if let Some(err) = token_map.error {
             return Err(Error::Response(err));
         }
 
-        if let Some(token) = token_map.remove("access_token") {
+        if let Some(token) = token_map.access_token {
             state.token = Some(token);
-            state.refresh = token_map.remove("refresh_token");
-            state.until = token_map.remove("expires_in");
+            state.refresh = token_map.refresh_token;
+            state.until = token_map.expires_in;
             return Ok(());
         }
 
@@ -150,21 +170,21 @@ impl Client {
         let token_response = client
             .execute(access_token_request)
             .map_err(|_| Error::RefreshFailed)?;
-        let mut token_map = parse_token_response(token_response)?;
+        let mut token_map: TokenMap = parse_token_response(token_response)?;
 
-        if token_map.get("error").is_some() || !token_map.get("access_token").is_some() {
+        if token_map.error.is_some() || !token_map.access_token.is_some() {
             return Err(Error::MissingToken);
         }
 
         let token = token_map
-            .remove("access_token")
+            .access_token
             .unwrap();
         state.token = Some(token);
         state.refresh = token_map
-            .remove("refresh_token")
+            .refresh_token
             .or(state.refresh.take());
         state.until = token_map
-            .remove("expires_in");
+            .expires_in;
         Ok(())
     }
 
@@ -173,7 +193,7 @@ impl Client {
     }
 }
 
-fn parse_token_response(mut response: Response) -> Result<HashMap<String, String>, serde_json::Error> {
+fn parse_token_response(mut response: Response) -> Result<TokenMap, serde_json::Error> {
     let mut token = String::new();
     response.read_to_string(&mut token).unwrap();
     serde_json::from_str(&token)

--- a/examples/support/client.rs
+++ b/examples/support/client.rs
@@ -2,7 +2,7 @@ extern crate reqwest;
 extern crate serde;
 extern crate serde_json;
 
-use serde::*;
+use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::collections::HashMap;
 use std::io::Read;

--- a/oxide-auth-iron/Cargo.toml
+++ b/oxide-auth-iron/Cargo.toml
@@ -21,5 +21,5 @@ url = "1.7"
 [dev-dependencies]
 reqwest = "0.9"
 router = "0.6.0"
-serde = "1.0"
+serde = { version =  "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/oxide-auth-rocket/Cargo.toml
+++ b/oxide-auth-rocket/Cargo.toml
@@ -19,5 +19,5 @@ serde_urlencoded = "0.5.1"
 
 [dev-dependencies]
 reqwest = "0.9"
-serde = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/oxide-auth-rouille/Cargo.toml
+++ b/oxide-auth-rouille/Cargo.toml
@@ -19,5 +19,5 @@ url = "1.7"
 
 [dev-dependencies]
 reqwest = "0.9"
-serde = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/oxide-auth/src/code_grant/accesstoken.rs
+++ b/oxide-auth/src/code_grant/accesstoken.rs
@@ -13,7 +13,7 @@ use primitives::registrar::{Registrar, RegistrarError};
 
 /// Token Response
 #[derive(Deserialize, Serialize)]
-pub struct TokenResponse {
+pub(crate) struct TokenResponse {
     /// The access token issued by the authorization server.
     #[serde(skip_serializing_if="Option::is_none")]
     pub access_token: Option<String>,

--- a/oxide-auth/src/code_grant/accesstoken.rs
+++ b/oxide-auth/src/code_grant/accesstoken.rs
@@ -358,7 +358,7 @@ impl BearerToken {
             #[serde(skip_serializing_if="Option::is_none")]
             refresh_token: Option<&'a str>,
             token_type: &'a str,
-            expires_in: String,
+            expires_in: i64,
             scope: &'a str,
         }
 
@@ -367,7 +367,7 @@ impl BearerToken {
             access_token: self.0.token.as_str(),
             refresh_token: self.0.refresh.as_ref().map(String::as_str),
             token_type: "bearer",
-            expires_in: remaining.num_seconds().to_string(),
+            expires_in: remaining.num_seconds(),
             scope: self.1.as_str(),
         };
 

--- a/oxide-auth/src/code_grant/refresh.rs
+++ b/oxide-auth/src/code_grant/refresh.rs
@@ -258,7 +258,7 @@ impl BearerToken {
             #[serde(skip_serializing_if="Option::is_none")]
             refresh_token: Option<&'a str>,
             token_type: &'a str,
-            expires_in: String,
+            expires_in: i64,
             scope: &'a str,
         }
 
@@ -267,7 +267,7 @@ impl BearerToken {
             access_token: self.0.token.as_str(),
             refresh_token: self.0.refresh.as_ref().map(String::as_str),
             token_type: "bearer",
-            expires_in: remaining.num_seconds().to_string(),
+            expires_in: remaining.num_seconds(),
             scope: self.1.as_str(),
         };
 

--- a/oxide-auth/src/endpoint/tests/refresh.rs
+++ b/oxide-auth/src/endpoint/tests/refresh.rs
@@ -11,6 +11,7 @@ use serde_json;
 
 use super::{Body, CraftedRequest, CraftedResponse, Status, ToSingleValueQuery};
 use super::defaults::*;
+use code_grant::accesstoken::TokenResponse;
 use frontends::simple::endpoint::{refresh_flow, resource_flow};
 
 struct RefreshTokenSetup {
@@ -104,15 +105,12 @@ impl RefreshTokenSetup {
             Some(Body::Json(body)) => body,
             _ => panic!("Expect json body"),
         };
-        let mut body: HashMap<String, String> = serde_json::from_str(&body)
+        let body: TokenResponse = serde_json::from_str(&body)
             .expect("Expected valid json body");
-        let duration: i64 = body.remove("expires_in")
-            .unwrap()
-            .parse()
-            .unwrap();
+        let duration = body.expires_in.unwrap();
         RefreshedToken {
-            token: body.remove("access_token").expect("Expected a token"),
-            refresh: body.remove("refresh_token"),
+            token: body.access_token.expect("Expected a token"),
+            refresh: body.refresh_token,
             until: Utc::now() + Duration::seconds(duration),
         }
     }


### PR DESCRIPTION
This changes/fixes/improves &#8230;

 - [x] I have read the [contribution guidelines][Contributing]
 - [x] This change has tests (remove for doc only)
 - [ ] This change has documentation
 - [ ] Corresponds to issue (number)

According to the example below, I changed `expires_in` to return a numeric value.

> https://tools.ietf.org/html/rfc6749#section-4.3.3

```
   An example successful response:

     HTTP/1.1 200 OK
     Content-Type: application/json;charset=UTF-8
     Cache-Control: no-store
     Pragma: no-cache

     {
       "access_token":"2YotnFZFEjr1zCsicMWpAA",
       "token_type":"example",
       "expires_in":3600,
       "refresh_token":"tGzv3JOkF0XG5Qx2TlKWIA",
       "example_parameter":"example_value"
     }
```

**Before**

```sh
$ curl -I -XPOST 'http://localhost:8020/authorize?client_id=LocalClient&redirect_uri=http%3A%2F%2Flocalhost%3A8021%2Fendpoint&response_type=code&allow=true'
HTTP/1.1 302 Found
content-length: 0
location: http://localhost:8021/endpoint?code=ixhKIRqYItJdvNxCsd5QSg%3D%3D
date: Fri, 21 Feb 2020 01:15:00 GMT

$ curl -XPOST 'http://localhost:8020/token' --data 'client_id=LocalClient&redirect_uri=http%3A%2F%2Flocalhost%3A8021%2Fendpoint&grant_type=authorization_code&code=ixhKIRqYItJdvNxCsd5QSg%3D%3D'
{"access_token":"3kvjahaZbUJf8nGS6yI2pw==","refresh_token":"Px8wy+CTJ+azEMVkeT3b8A==","token_type":"bearer","expires_in":"3599","scope":"default-scope"}% 

$ curl -XPOST 'http://localhost:8020/refresh' --data 'client_id=LocalClient&redirect_uri=http%3A%2F%2Flocalhost%3A8021%2Fendpoint&grant_type=refresh_token' --data-urlencode 'refresh_token=Px8wy+CTJ+azEMVkeT3b8A=='
{"scope":"default-scope","expires_in":"3599","access_token":"0eVLML3J+LdIDyhqP2yrlw==","token_type":"bearer"}% 
```

**After**

```sh
$ curl -I -XPOST 'http://localhost:8020/authorize?client_id=LocalClient&redirect_uri=http%3A%2F%2Flocalhost%3A8021%2Fendpoint&response_type=code&allow=true'

HTTP/1.1 302 Found
content-length: 0
location: http://localhost:8021/endpoint?code=6JrHeuMu%2BjXRLGgLN7abFg%3D%3D
date: Fri, 21 Feb 2020 01:16:26 GMT

$ curl -XPOST 'http://localhost:8020/token' --data 'client_id=LocalClient&redirect_uri=http%3A%2F%2Flocalhost%3A8021%2Fendpoint&grant_type=authorization_code&code=6JrHeuMu%2BjXRLGgLN7abFg%3D%3D'
{"access_token":"n+8OMaRPGfgYyx+oWyPRcA==","refresh_token":"+iIMbVOobb5rXMtgdZTrEw==","token_type":"bearer","expires_in":3599,"scope":"default-scope"}%

$ curl -XPOST 'http://localhost:8020/refresh' --data 'client_id=LocalClient&redirect_uri=http%3A%2F%2Flocalhost%3A8021%2Fendpoint&grant_type=refresh_token' --data-urlencode 'refresh_token=+iIMbVOobb5rXMtgdZTrEw=='
{"access_token":"5pAtaWp8x10o3S1I0Mq6gw==","token_type":"bearer","expires_in":3599,"scope":"default-scope"}%
```