### PR TITLE
async for authorization

### DIFF
--- a/oxide-auth-async/Cargo.toml
+++ b/oxide-auth-async/Cargo.toml
@@ -11,10 +11,10 @@ edition = "2018"
 async-trait = "0.1.21"
 oxide-auth = { path = "../oxide-auth" }
 base64 = "0.9"
-
-[dev-dependencies]
 url = "1.7"
 chrono = "0.4.2"
+
+[dev-dependencies]
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"

--- a/oxide-auth-async/src/endpoint/authorization.rs
+++ b/oxide-auth-async/src/endpoint/authorization.rs
@@ -1,0 +1,332 @@
+use std::{borrow::Cow, marker::PhantomData};
+
+use oxide_auth::{
+    endpoint::{WebResponse, QueryParameter},
+    code_grant::authorization::{Error as AuthorizationError, Request as AuthorizationRequest},
+};
+
+use crate::code_grant::authorization::{
+    authorization_code, Endpoint as AuthorizationEndpoint, Extension, Pending,
+};
+
+use super::*;
+use url::Url;
+
+/// All relevant methods for handling authorization code requests.
+pub struct AuthorizationFlow<E, R>
+where
+    E: Endpoint<R>,
+    R: WebRequest,
+{
+    endpoint: WrappedAuthorization<E, R>,
+}
+
+struct WrappedAuthorization<E: Endpoint<R>, R: WebRequest> {
+    inner: E,
+    extension_fallback: (),
+    r_type: PhantomData<R>,
+}
+
+struct WrappedRequest<'a, R: WebRequest + 'a> {
+    /// Original request.
+    request: PhantomData<R>,
+
+    /// The query in the url.
+    query: Cow<'a, dyn QueryParameter + 'static>,
+
+    /// An error if one occurred.
+    error: Option<R::Error>,
+}
+
+struct AuthorizationPending<'a, E: 'a, R: 'a>
+where
+    E: Endpoint<R>,
+    R: WebRequest,
+{
+    endpoint: &'a mut WrappedAuthorization<E, R>,
+    pending: Pending,
+    request: R,
+}
+
+/// A processed authentication request that may be waiting for authorization by the resource owner.
+///
+/// Note that this borrows from the `AuthorizationFlow` used to create it. You can `finish` the
+/// authorization flow for this request to produce a response or an error.
+struct AuthorizationPartial<'a, E: 'a, R: 'a>
+where
+    E: Endpoint<R>,
+    R: WebRequest,
+{
+    inner: AuthorizationPartialInner<'a, E, R>,
+
+    /// TODO: offer this in the public api instead of dropping the request.
+    _with_request: Option<Box<dyn FnOnce(R) -> ()>>,
+}
+
+/// Result type from processing an authentication request.
+enum AuthorizationPartialInner<'a, E: 'a, R: 'a>
+where
+    E: Endpoint<R>,
+    R: WebRequest,
+{
+    /// No error happened during processing and the resource owner can decide over the grant.
+    Pending {
+        /// A utility struct with which the request can be decided.
+        pending: AuthorizationPending<'a, E, R>,
+    },
+
+    /// The request was faulty, e.g. wrong client data, but there is a well defined response.
+    Failed {
+        /// The request passed in.
+        request: R,
+
+        /// Final response to the client.
+        ///
+        /// This should be forwarded unaltered to the client. Modifications and amendments risk
+        /// deviating from the OAuth2 rfc, enabling DoS, or even leaking secrets. Modify with care.
+        response: R::Response,
+    },
+
+    /// An internal error happened during the request.
+    Error {
+        /// The request passed in.
+        request: R,
+
+        /// Error that happened while handling the request.
+        error: E::Error,
+    },
+}
+
+impl<E, R> AuthorizationFlow<E, R>
+where
+    E: Endpoint<R>,
+    R: WebRequest,
+{
+    /// Check that the endpoint supports the necessary operations for handling requests.
+    ///
+    /// Binds the endpoint to a particular type of request that it supports, for many
+    /// implementations this is probably single type anyways.
+    ///
+    /// ## Panics
+    ///
+    /// Indirectly `execute` may panic when this flow is instantiated with an inconsistent
+    /// endpoint, for details see the documentation of `Endpoint`. For consistent endpoints,
+    /// the panic is instead caught as an error here.
+    pub fn prepare(mut endpoint: E) -> Result<Self, E::Error> {
+        if endpoint.registrar().is_none() {
+            return Err(endpoint.error(OAuthError::PrimitiveError));
+        }
+
+        if endpoint.authorizer_mut().is_none() {
+            return Err(endpoint.error(OAuthError::PrimitiveError));
+        }
+
+        Ok(AuthorizationFlow {
+            endpoint: WrappedAuthorization {
+                inner: endpoint,
+                extension_fallback: (),
+                r_type: PhantomData,
+            },
+        })
+    }
+
+    /// Use the checked endpoint to execute the authorization flow for a request.
+    ///
+    /// In almost all cases this is followed by executing `finish` on the result but some users may
+    /// instead want to inspect the partial result.
+    ///
+    /// ## Panics
+    ///
+    /// When the registrar or the authorizer returned by the endpoint is suddenly `None` when
+    /// previously it was `Some(_)`.
+    pub async fn execute(&mut self, mut request: R) -> Result<R::Response, E::Error> {
+        let negotiated =
+            authorization_code(&mut self.endpoint, &WrappedRequest::new(&mut request)).await;
+
+        let inner = match negotiated {
+            Err(err) => match authorization_error(&mut self.endpoint.inner, &mut request, err) {
+                Ok(response) => AuthorizationPartialInner::Failed { request, response },
+                Err(error) => AuthorizationPartialInner::Error { request, error },
+            },
+            Ok(negotiated) => AuthorizationPartialInner::Pending {
+                pending: AuthorizationPending {
+                    endpoint: &mut self.endpoint,
+                    pending: negotiated,
+                    request,
+                },
+            },
+        };
+
+        let partial = AuthorizationPartial {
+            inner,
+            _with_request: None,
+        };
+
+        partial.finish().await
+    }
+}
+
+impl<'a, E: Endpoint<R>, R: WebRequest> AuthorizationPartial<'a, E, R> {
+    /// Finish the authentication step.
+    ///
+    /// If authorization has not yet produced a hard error or an explicit response, executes the
+    /// owner solicitor of the endpoint to determine owner consent.
+    pub async fn finish(self) -> Result<R::Response, E::Error> {
+        let (_request, result) = match self.inner {
+            AuthorizationPartialInner::Pending { pending } => pending.finish().await,
+            AuthorizationPartialInner::Failed { request, response } => (request, Ok(response)),
+            AuthorizationPartialInner::Error { request, error } => (request, Err(error)),
+        };
+
+        result
+    }
+}
+
+fn authorization_error<E: Endpoint<R>, R: WebRequest>(
+    endpoint: &mut E, request: &mut R, error: AuthorizationError,
+) -> Result<R::Response, E::Error> {
+    match error {
+        AuthorizationError::Ignore => Err(endpoint.error(OAuthError::DenySilently)),
+        AuthorizationError::Redirect(mut target) => {
+            let mut response =
+                endpoint.response(request, Template::new_redirect(Some(target.description())))?;
+            response
+                .redirect(target.into())
+                .map_err(|err| endpoint.web_error(err))?;
+            Ok(response)
+        }
+        AuthorizationError::PrimitiveError => Err(endpoint.error(OAuthError::PrimitiveError)),
+    }
+}
+
+impl<'a, E: Endpoint<R>, R: WebRequest> AuthorizationPending<'a, E, R> {
+    /// Resolve the pending status using the endpoint to query owner consent.
+    async fn finish(mut self) -> (R, Result<R::Response, E::Error>) {
+        let checked = self
+            .endpoint
+            .owner_solicitor()
+            .check_consent(&mut self.request, self.pending.pre_grant())
+            .await;
+
+        match checked {
+            OwnerConsent::Denied => self.deny(),
+            OwnerConsent::InProgress(resp) => self.in_progress(resp),
+            OwnerConsent::Authorized(who) => self.authorize(who).await,
+            OwnerConsent::Error(err) => (self.request, Err(self.endpoint.inner.web_error(err))),
+        }
+    }
+
+    /// Postpones the decision over the request, to display data to the resource owner.
+    ///
+    /// This should happen at least once for each request unless the resource owner has already
+    /// acknowledged and pre-approved a specific grant.  The response can also be used to determine
+    /// the resource owner, if no login has been detected or if multiple accounts are allowed to be
+    /// logged in at the same time.
+    fn in_progress(self, response: R::Response) -> (R, Result<R::Response, E::Error>) {
+        (self.request, Ok(response))
+    }
+
+    /// Denies the request, the client is not allowed access.
+    fn deny(mut self) -> (R, Result<R::Response, E::Error>) {
+        let result = self.pending.deny();
+        let result = Self::convert_result(result, &mut self.endpoint.inner, &mut self.request);
+
+        (self.request, result)
+    }
+
+    /// Tells the system that the resource owner with the given id has approved the grant.
+    async fn authorize(mut self, who: String) -> (R, Result<R::Response, E::Error>) {
+        let result = self.pending.authorize(self.endpoint, who.into()).await;
+        let result = Self::convert_result(result, &mut self.endpoint.inner, &mut self.request);
+
+        (self.request, result)
+    }
+
+    fn convert_result(
+        result: Result<Url, AuthorizationError>, endpoint: &mut E, request: &mut R,
+    ) -> Result<R::Response, E::Error> {
+        match result {
+            Ok(url) => {
+                let mut response = endpoint.response(request, Template::new_redirect(None))?;
+                response.redirect(url).map_err(|err| endpoint.web_error(err))?;
+                Ok(response)
+            }
+            Err(err) => authorization_error(endpoint, request, err),
+        }
+    }
+}
+
+impl<E: Endpoint<R>, R: WebRequest> WrappedAuthorization<E, R> {
+    fn owner_solicitor(&mut self) -> &mut dyn OwnerSolicitor<R> {
+        self.inner.owner_solicitor().unwrap()
+    }
+}
+
+impl<E: Endpoint<R>, R: WebRequest> AuthorizationEndpoint for WrappedAuthorization<E, R> {
+    fn registrar(&self) -> &dyn Registrar {
+        self.inner.registrar().unwrap()
+    }
+
+    fn authorizer(&mut self) -> &mut dyn Authorizer {
+        self.inner.authorizer_mut().unwrap()
+    }
+
+    fn extension(&mut self) -> &mut dyn Extension {
+        self.inner
+            .extension()
+            .and_then(super::Extension::authorization)
+            .unwrap_or(&mut self.extension_fallback)
+    }
+}
+
+impl<'a, R: WebRequest + 'a> WrappedRequest<'a, R> {
+    pub fn new(request: &'a mut R) -> Self {
+        Self::new_or_fail(request).unwrap_or_else(Self::from_err)
+    }
+
+    fn new_or_fail(request: &'a mut R) -> Result<Self, R::Error> {
+        Ok(WrappedRequest {
+            request: PhantomData,
+            query: request.query()?,
+            error: None,
+        })
+    }
+
+    fn from_err(err: R::Error) -> Self {
+        WrappedRequest {
+            request: PhantomData,
+            query: Cow::Owned(Default::default()),
+            error: Some(err),
+        }
+    }
+}
+
+impl<'a, R: WebRequest + 'a> AuthorizationRequest for WrappedRequest<'a, R> {
+    fn valid(&self) -> bool {
+        self.error.is_none()
+    }
+
+    fn client_id(&self) -> Option<Cow<str>> {
+        self.query.unique_value("client_id")
+    }
+
+    fn scope(&self) -> Option<Cow<str>> {
+        self.query.unique_value("scope")
+    }
+
+    fn redirect_uri(&self) -> Option<Cow<str>> {
+        self.query.unique_value("redirect_uri")
+    }
+
+    fn state(&self) -> Option<Cow<str>> {
+        self.query.unique_value("state")
+    }
+
+    fn response_type(&self) -> Option<Cow<str>> {
+        self.query.unique_value("response_type")
+    }
+
+    fn extension(&self, key: &str) -> Option<Cow<str>> {
+        self.query.unique_value(key)
+    }
+}

--- a/oxide-auth-async/src/endpoint/mod.rs
+++ b/oxide-auth-async/src/endpoint/mod.rs
@@ -3,8 +3,10 @@ use oxide_auth::endpoint::{OAuthError, Template, WebRequest, OwnerConsent, PreGr
 
 // pub use crate::code_grant::authorization::Extension as AuthorizationExtension;
 pub use crate::code_grant::access_token::Extension as AccessTokenExtension;
+pub use crate::code_grant::authorization::Extension as AuthorizationExtension;
 use crate::primitives::{Authorizer, Registrar, Issuer};
 
+pub mod authorization;
 pub mod access_token;
 pub mod refresh;
 pub mod resource;
@@ -35,7 +37,7 @@ pub trait Endpoint<Request: WebRequest> {
     ///
     /// Returning `None` will implicated failing the authorization code flow but does have any
     /// effect on other flows.
-    // fn owner_solicitor(&mut self) -> Option<&mut dyn OwnerSolicitor<Request>>;
+    fn owner_solicitor(&mut self) -> Option<&mut dyn OwnerSolicitor<Request>>;
 
     /// Determine the required scopes for a request.
     ///
@@ -66,11 +68,10 @@ pub trait Endpoint<Request: WebRequest> {
 }
 
 pub trait Extension {
-    // FIXME
-    // /// The handler for authorization code extensions.
-    // fn authorization(&mut self) -> Option<&mut dyn AuthorizationExtension> {
-    //     None
-    // }
+    /// The handler for authorization code extensions.
+    fn authorization(&mut self) -> Option<&mut dyn AuthorizationExtension> {
+        None
+    }
 
     /// The handler for access token extensions.
     fn access_token(&mut self) -> Option<&mut dyn AccessTokenExtension> {

--- a/oxide-auth-async/src/tests/access_token.rs
+++ b/oxide-auth-async/src/tests/access_token.rs
@@ -75,6 +75,9 @@ impl<'a> Endpoint<CraftedRequest> for AccessTokenEndpoint<'a> {
     fn scopes(&mut self) -> Option<&mut dyn oxide_auth::endpoint::Scopes<CraftedRequest>> {
         None
     }
+    fn owner_solicitor(&mut self) -> Option<&mut dyn crate::endpoint::OwnerSolicitor<CraftedRequest>> {
+        None
+    }
 }
 
 impl AccessTokenSetup {

--- a/oxide-auth-async/src/tests/authorization.rs
+++ b/oxide-auth-async/src/tests/authorization.rs
@@ -1,0 +1,304 @@
+use std::collections::HashMap;
+
+use oxide_auth::primitives::authorizer::AuthMap;
+use oxide_auth::{
+    primitives::registrar::{Client, ClientMap},
+    frontends::simple::endpoint::Error,
+    endpoint::WebRequest,
+};
+
+use crate::endpoint::{Endpoint, OwnerSolicitor, authorization::AuthorizationFlow};
+
+use super::{CraftedRequest, Status, TestGenerator, ToSingleValueQuery};
+use super::{Allow, Deny};
+use super::defaults::*;
+
+struct AuthorizationEndpoint<'a> {
+    registrar: &'a ClientMap,
+    authorizer: &'a mut AuthMap<TestGenerator>,
+    solicitor: &'a mut dyn OwnerSolicitor<CraftedRequest>,
+}
+
+impl<'a> AuthorizationEndpoint<'a> {
+    fn new(
+        registrar: &'a ClientMap, authorizer: &'a mut AuthMap<TestGenerator>,
+        solicitor: &'a mut dyn OwnerSolicitor<CraftedRequest>,
+    ) -> Self {
+        Self {
+            registrar,
+            authorizer,
+            solicitor,
+        }
+    }
+}
+
+impl<'a> Endpoint<CraftedRequest> for AuthorizationEndpoint<'a> {
+    type Error = Error<CraftedRequest>;
+
+    fn registrar(&self) -> Option<&dyn crate::primitives::Registrar> {
+        Some(self.registrar)
+    }
+    fn authorizer_mut(&mut self) -> Option<&mut dyn crate::primitives::Authorizer> {
+        Some(self.authorizer)
+    }
+    fn issuer_mut(&mut self) -> Option<&mut dyn crate::primitives::Issuer> {
+        None
+    }
+    fn scopes(&mut self) -> Option<&mut dyn oxide_auth::endpoint::Scopes<CraftedRequest>> {
+        None
+    }
+    fn response(
+        &mut self, _request: &mut CraftedRequest, _kind: oxide_auth::endpoint::Template,
+    ) -> Result<<CraftedRequest as WebRequest>::Response, Self::Error> {
+        Ok(Default::default())
+    }
+    fn error(&mut self, err: oxide_auth::endpoint::OAuthError) -> Self::Error {
+        Error::OAuth(err)
+    }
+    fn web_error(&mut self, err: <CraftedRequest as WebRequest>::Error) -> Self::Error {
+        Error::Web(err)
+    }
+    fn owner_solicitor(&mut self) -> Option<&mut dyn OwnerSolicitor<CraftedRequest>> {
+        Some(self.solicitor)
+    }
+}
+
+struct AuthorizationSetup {
+    registrar: ClientMap,
+    authorizer: AuthMap<TestGenerator>,
+}
+
+impl AuthorizationSetup {
+    fn new() -> AuthorizationSetup {
+        let mut registrar = ClientMap::new();
+        let authorizer = AuthMap::new(TestGenerator("AuthToken".to_string()));
+
+        let client = Client::confidential(
+            EXAMPLE_CLIENT_ID,
+            EXAMPLE_REDIRECT_URI.parse().unwrap(),
+            EXAMPLE_SCOPE.parse().unwrap(),
+            EXAMPLE_PASSPHRASE.as_bytes(),
+        );
+        registrar.register_client(client);
+        AuthorizationSetup {
+            registrar,
+            authorizer,
+        }
+    }
+
+    fn test_success(&mut self, request: CraftedRequest) {
+        let mut solicitor = Allow(EXAMPLE_OWNER_ID.to_string());
+        let mut authorization_flow = AuthorizationFlow::prepare(AuthorizationEndpoint::new(
+            &mut self.registrar,
+            &mut self.authorizer,
+            &mut solicitor,
+        ))
+        .unwrap();
+        let response = smol::run(authorization_flow.execute(request)).expect("Should not error");
+
+        assert_eq!(response.status, Status::Redirect);
+
+        match response.location {
+            Some(ref url) if url.as_str().find("error").is_none() => (),
+            other => panic!("Expected successful redirect: {:?}", other),
+        }
+    }
+
+    fn test_silent_error(&mut self, request: CraftedRequest) {
+        let mut solicitor = Allow(EXAMPLE_OWNER_ID.to_string());
+        let mut authorization_flow = AuthorizationFlow::prepare(AuthorizationEndpoint::new(
+            &mut self.registrar,
+            &mut self.authorizer,
+            &mut solicitor,
+        ))
+        .unwrap();
+        match smol::run(authorization_flow.execute(request)) {
+            Ok(ref resp) if resp.location.is_some() => panic!("Redirect without client id {:?}", resp),
+            Ok(resp) => panic!("Response without client id {:?}", resp),
+            Err(_) => (),
+        }
+    }
+
+    fn test_error_redirect<P>(&mut self, request: CraftedRequest, mut pagehandler: P)
+    where
+        P: OwnerSolicitor<CraftedRequest>,
+    {
+        let mut authorization_flow = AuthorizationFlow::prepare(AuthorizationEndpoint::new(
+            &mut self.registrar,
+            &mut self.authorizer,
+            &mut pagehandler,
+        ))
+        .unwrap();
+        let response = smol::run(authorization_flow.execute(request));
+
+        let response = match response {
+            Err(resp) => panic!("Expected redirect with error set: {:?}", resp),
+            Ok(resp) => resp,
+        };
+
+        match response.location {
+            Some(ref url)
+                if url
+                    .query_pairs()
+                    .collect::<HashMap<_, _>>()
+                    .get("error")
+                    .is_some() =>
+            {
+                ()
+            }
+            other => panic!("Expected location with error set description: {:?}", other),
+        }
+    }
+}
+
+#[test]
+fn auth_success() {
+    let success = CraftedRequest {
+        query: Some(
+            vec![
+                ("response_type", "code"),
+                ("client_id", EXAMPLE_CLIENT_ID),
+                ("redirect_uri", EXAMPLE_REDIRECT_URI),
+            ]
+            .iter()
+            .to_single_value_query(),
+        ),
+        urlbody: None,
+        auth: None,
+    };
+
+    AuthorizationSetup::new().test_success(success);
+}
+
+#[test]
+fn auth_request_silent_missing_client() {
+    let missing_client = CraftedRequest {
+        query: Some(vec![("response_type", "code")].iter().to_single_value_query()),
+        urlbody: None,
+        auth: None,
+    };
+
+    AuthorizationSetup::new().test_silent_error(missing_client);
+}
+
+#[test]
+fn auth_request_silent_unknown_client() {
+    // The client_id is not registered
+    let unknown_client = CraftedRequest {
+        query: Some(
+            vec![
+                ("response_type", "code"),
+                ("client_id", "SomeOtherClient"),
+                ("redirect_uri", "https://wrong.client.example/endpoint"),
+            ]
+            .iter()
+            .to_single_value_query(),
+        ),
+        urlbody: None,
+        auth: None,
+    };
+
+    AuthorizationSetup::new().test_silent_error(unknown_client);
+}
+
+#[test]
+fn auth_request_silent_mismatching_redirect() {
+    // The redirect_uri does not match
+    let mismatching_redirect = CraftedRequest {
+        query: Some(
+            vec![
+                ("response_type", "code"),
+                ("client_id", EXAMPLE_CLIENT_ID),
+                ("redirect_uri", "https://wrong.client.example/endpoint"),
+            ]
+            .iter()
+            .to_single_value_query(),
+        ),
+        urlbody: None,
+        auth: None,
+    };
+
+    AuthorizationSetup::new().test_silent_error(mismatching_redirect);
+}
+
+#[test]
+fn auth_request_silent_invalid_redirect() {
+    // The redirect_uri is not an uri ('\' is not allowed to appear in the scheme)
+    let invalid_redirect = CraftedRequest {
+        query: Some(
+            vec![
+                ("response_type", "code"),
+                ("client_id", EXAMPLE_CLIENT_ID),
+                ("redirect_uri", "\\://"),
+            ]
+            .iter()
+            .to_single_value_query(),
+        ),
+        urlbody: None,
+        auth: None,
+    };
+
+    AuthorizationSetup::new().test_silent_error(invalid_redirect);
+}
+
+#[test]
+fn auth_request_error_denied() {
+    // Used in conjunction with a denying authorization handler below
+    let denied_request = CraftedRequest {
+        query: Some(
+            vec![
+                ("response_type", "code"),
+                ("client_id", EXAMPLE_CLIENT_ID),
+                ("redirect_uri", EXAMPLE_REDIRECT_URI),
+            ]
+            .iter()
+            .to_single_value_query(),
+        ),
+        urlbody: None,
+        auth: None,
+    };
+
+    AuthorizationSetup::new().test_error_redirect(denied_request, Deny);
+}
+
+#[test]
+fn auth_request_error_unsupported_method() {
+    // Requesting an authorization token for a method other than code
+    let unsupported_method = CraftedRequest {
+        query: Some(
+            vec![
+                ("response_type", "other_method"),
+                ("client_id", EXAMPLE_CLIENT_ID),
+                ("redirect_uri", EXAMPLE_REDIRECT_URI),
+            ]
+            .iter()
+            .to_single_value_query(),
+        ),
+        urlbody: None,
+        auth: None,
+    };
+
+    AuthorizationSetup::new()
+        .test_error_redirect(unsupported_method, Allow(EXAMPLE_OWNER_ID.to_string()));
+}
+
+#[test]
+fn auth_request_error_malformed_scope() {
+    // A scope with malformed formatting
+    let malformed_scope = CraftedRequest {
+        query: Some(
+            vec![
+                ("response_type", "code"),
+                ("client_id", EXAMPLE_CLIENT_ID),
+                ("redirect_uri", EXAMPLE_REDIRECT_URI),
+                ("scope", "\"no quotes (0x22) allowed\""),
+            ]
+            .iter()
+            .to_single_value_query(),
+        ),
+        urlbody: None,
+        auth: None,
+    };
+
+    AuthorizationSetup::new().test_error_redirect(malformed_scope, Allow(EXAMPLE_OWNER_ID.to_string()));
+}

--- a/oxide-auth-async/src/tests/mod.rs
+++ b/oxide-auth-async/src/tests/mod.rs
@@ -211,7 +211,7 @@ pub mod defaults {
     pub const EXAMPLE_SCOPE: &str = "example default";
 }
 
-// mod authorization;
+mod authorization;
 mod access_token;
 mod resource;
 mod refresh;

--- a/oxide-auth-async/src/tests/refresh.rs
+++ b/oxide-auth-async/src/tests/refresh.rs
@@ -58,6 +58,9 @@ impl<'a> Endpoint<CraftedRequest> for RefreshTokenEndpoint<'a> {
     fn scopes(&mut self) -> Option<&mut dyn oxide_auth::endpoint::Scopes<CraftedRequest>> {
         None
     }
+    fn owner_solicitor(&mut self) -> Option<&mut dyn crate::endpoint::OwnerSolicitor<CraftedRequest>> {
+        None
+    }
 }
 
 struct RefreshTokenSetup {

--- a/oxide-auth-async/src/tests/resource.rs
+++ b/oxide-auth-async/src/tests/resource.rs
@@ -42,6 +42,9 @@ impl<'a> Endpoint<CraftedRequest> for ResourceEndpoint<'a> {
     fn scopes(&mut self) -> Option<&mut dyn oxide_auth::endpoint::Scopes<CraftedRequest>> {
         Some(&mut self.scopes)
     }
+    fn owner_solicitor(&mut self) -> Option<&mut dyn crate::endpoint::OwnerSolicitor<CraftedRequest>> {
+        None
+    }
 }
 
 impl<'a> ResourceEndpoint<'a> {

--- a/oxide-auth/src/code_grant/accesstoken.rs
+++ b/oxide-auth/src/code_grant/accesstoken.rs
@@ -140,7 +140,7 @@ pub enum Input<'req> {
     Request(&'req dyn Request),
     Authenticated,
     Recovered(Option<Grant>),
-    Done,
+    Extended { access_extensions: Extensions },
     Issued(IssuedToken),
     None,
 }
@@ -189,13 +189,9 @@ impl AccessToken {
                 },
                 Input::Recovered(grant),
             ) => Self::recovered(client, redirect_uri, grant).unwrap_or_else(AccessTokenState::Err),
-            (
-                AccessTokenState::Extend {
-                    saved_params,
-                    extensions,
-                },
-                Input::Done,
-            ) => Self::issue(saved_params, extensions),
+            (AccessTokenState::Extend { saved_params, .. }, Input::Extended { access_extensions }) => {
+                Self::issue(saved_params, access_extensions)
+            }
             (AccessTokenState::Issue { grant }, Input::Issued(token)) => {
                 return Output::Ok(Self::finish(grant, token));
             }
@@ -369,18 +365,12 @@ pub fn access_token(handler: &mut dyn Endpoint, request: &dyn Request) -> Result
                 })?;
                 Input::Recovered(opt_grant)
             }
-            Requested::Extend {
-                grant: _,
-                mut extensions,
-            } => {
-                let mut access_extensions = handler
+            Requested::Extend { grant: _, extensions } => {
+                let access_extensions = handler
                     .extension()
                     .extend(request, extensions.clone())
                     .map_err(|_| Error::invalid())?;
-                // FIXME: it that right? access_extensions seems to be lost but tests are passing
-                // and clippy is complaining
-                extensions = &mut access_extensions;
-                Input::Done
+                Input::Extended { access_extensions }
             }
             Requested::Issue { grant } => {
                 let token = handler.issuer().issue(grant.clone()).map_err(|_| {

--- a/oxide-auth/src/code_grant/error.rs
+++ b/oxide-auth/src/code_grant/error.rs
@@ -71,7 +71,7 @@ impl AuthorizationError {
         }
     }
 
-    pub(crate) fn set_type(&mut self, new_type: AuthorizationErrorType) {
+    pub fn set_type(&mut self, new_type: AuthorizationErrorType) {
         self.error = new_type;
     }
 

--- a/oxide-auth/src/endpoint/mod.rs
+++ b/oxide-auth/src/endpoint/mod.rs
@@ -390,6 +390,11 @@ impl<'a> Template<'a> {
         .into()
     }
 
+    /// Create a redirect template
+    pub fn new_redirect(authorization_error: Option<&'a mut AuthorizationError>) -> Self {
+        InnerTemplate::Redirect { authorization_error }.into()
+    }
+
     /// The corresponding status code.
     pub fn status(&self) -> ResponseStatus {
         match self.inner {


### PR DESCRIPTION
I'm opening the PR to get help because it doesn't compile and I'm kinda stuck :( 

```
error[E0499]: cannot borrow `authorization` as mutable more than once at a time
   --> oxide-auth\src\code_grant\authorization.rs:332:27
    |
332 |         requested = match authorization.advance(input) {
    |                           ^^^^^^^^^^^^^ mutable borrow starts here in previous iteration of loop
```

I'm wondering why I get this error when I'm doing things in a similar way to other flows :-/

