### PR TITLE
Add access to scopes in the Scope struct

### DIFF
--- a/oxide-auth/src/primitives/scope.rs
+++ b/oxide-auth/src/primitives/scope.rs
@@ -70,6 +70,11 @@ impl Scope {
     pub fn allow_access(&self, rhs: &Scope) -> bool {
         self <= rhs
     }
+
+    /// Create an iterator over the individual scopes.
+    pub fn iter(&self) -> impl Iterator<Item=&str> {
+        self.tokens.iter().map(AsRef::as_ref)
+    }
 }
 
 /// Error returned from parsing a scope as encoded in an authorization token request.
@@ -189,5 +194,15 @@ mod tests {
         assert!(!scope_base.priviledged_to(&scope_uncmp));
         assert!(!scope_uncmp.allow_access(&scope_less));
         assert!(!scope_uncmp.allow_access(&scope_base));
+    }
+
+    #[test]
+    fn test_iterating() {
+        let scope = "cap1 cap2 cap3".parse::<Scope>().unwrap();
+        let all = scope.iter().collect::<Vec<_>>();
+        assert_eq!(all.len(), 3);
+        assert!(all.contains(&"cap1"));
+        assert!(all.contains(&"cap2"));
+        assert!(all.contains(&"cap3"));
     }
 }


### PR DESCRIPTION
This solves #92, by adding support for a `iter()` method that gives an iterator over the scopes in the given Scope.

 - [x] I have read the [contribution guidelines][Contributing]
 - [x] This change has tests (remove for doc only)
 - [x] This change has documentation
 - [x] Corresponds to issue (#92)

I license past and future contributions under the dual MIT/Apache-2.0 license, allowing licensees to chose either at their option.

[Contributing]: CONTRIBUTING.md
