### PR TITLE
Split client's URL into exact and semantic

### DIFF
--- a/oxide-auth-actix/examples/actix-example/src/main.rs
+++ b/oxide-auth-actix/examples/actix-example/src/main.rs
@@ -131,7 +131,10 @@ impl State {
                 // A registrar with one pre-registered client
                 registrar: vec![Client::public(
                     "LocalClient",
-                    "http://localhost:8021/endpoint".parse().unwrap(),
+                    "http://localhost:8021/endpoint"
+                        .parse::<url::Url>()
+                        .unwrap()
+                        .into(),
                     "default-scope".parse().unwrap(),
                 )]
                 .into_iter()

--- a/oxide-auth-async/src/tests/access_token.rs
+++ b/oxide-auth-async/src/tests/access_token.rs
@@ -3,7 +3,7 @@ use oxide_auth::primitives::issuer::TokenMap;
 use oxide_auth::primitives::grant::{Grant, Extensions};
 use oxide_auth::{
     frontends::simple::endpoint::Error,
-    primitives::registrar::{Client, ClientMap},
+    primitives::registrar::{Client, ClientMap, RegisteredUrl},
     endpoint::WebRequest,
 };
 
@@ -90,7 +90,7 @@ impl AccessTokenSetup {
 
         let client = Client::confidential(
             EXAMPLE_CLIENT_ID,
-            EXAMPLE_REDIRECT_URI.parse().unwrap(),
+            RegisteredUrl::Semantic(EXAMPLE_REDIRECT_URI.parse().unwrap()),
             EXAMPLE_SCOPE.parse().unwrap(),
             EXAMPLE_PASSPHRASE.as_bytes(),
         );
@@ -126,7 +126,7 @@ impl AccessTokenSetup {
 
         let client = Client::public(
             EXAMPLE_CLIENT_ID,
-            EXAMPLE_REDIRECT_URI.parse().unwrap(),
+            RegisteredUrl::Semantic(EXAMPLE_REDIRECT_URI.parse().unwrap()),
             EXAMPLE_SCOPE.parse().unwrap(),
         );
 
@@ -273,7 +273,7 @@ fn access_equivalent_url() {
 
     let confusing_client = Client::public(
         CLIENT_ID,
-        REDIRECT_URL.parse().unwrap(),
+        RegisteredUrl::Semantic(REDIRECT_URL.parse().unwrap()),
         EXAMPLE_SCOPE.parse().unwrap(),
     );
 

--- a/oxide-auth-async/src/tests/authorization.rs
+++ b/oxide-auth-async/src/tests/authorization.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use oxide_auth::primitives::authorizer::AuthMap;
 use oxide_auth::{
-    primitives::registrar::{Client, ClientMap},
+    primitives::registrar::{Client, ClientMap, RegisteredUrl},
     frontends::simple::endpoint::Error,
     endpoint::WebRequest,
 };
@@ -75,7 +75,7 @@ impl AuthorizationSetup {
 
         let client = Client::confidential(
             EXAMPLE_CLIENT_ID,
-            EXAMPLE_REDIRECT_URI.parse().unwrap(),
+            RegisteredUrl::Exact(EXAMPLE_REDIRECT_URI.parse().unwrap()),
             EXAMPLE_SCOPE.parse().unwrap(),
             EXAMPLE_PASSPHRASE.as_bytes(),
         );

--- a/oxide-auth-async/src/tests/refresh.rs
+++ b/oxide-auth-async/src/tests/refresh.rs
@@ -4,7 +4,7 @@ use oxide_auth::primitives::grant::{Grant, Extensions};
 use oxide_auth::{
     code_grant::accesstoken::TokenResponse,
     endpoint::{WebRequest},
-    primitives::registrar::{Client, ClientMap},
+    primitives::registrar::{Client, ClientMap, RegisteredUrl},
     frontends::simple::endpoint::Error,
 };
 
@@ -81,7 +81,7 @@ impl RefreshTokenSetup {
 
         let client = Client::confidential(
             EXAMPLE_CLIENT_ID,
-            EXAMPLE_REDIRECT_URI.parse().unwrap(),
+            RegisteredUrl::Semantic(EXAMPLE_REDIRECT_URI.parse().unwrap()),
             EXAMPLE_SCOPE.parse().unwrap(),
             EXAMPLE_PASSPHRASE.as_bytes(),
         );
@@ -119,7 +119,7 @@ impl RefreshTokenSetup {
 
         let client = Client::public(
             EXAMPLE_CLIENT_ID,
-            EXAMPLE_REDIRECT_URI.parse().unwrap(),
+            RegisteredUrl::Semantic(EXAMPLE_REDIRECT_URI.parse().unwrap()),
             EXAMPLE_SCOPE.parse().unwrap(),
         );
 
@@ -295,7 +295,7 @@ fn public_private_invalid_grant() {
     let mut setup = RefreshTokenSetup::public_client();
     let client = Client::confidential(
         "PrivateClient".into(),
-        EXAMPLE_REDIRECT_URI.parse().unwrap(),
+        RegisteredUrl::Semantic(EXAMPLE_REDIRECT_URI.parse().unwrap()),
         EXAMPLE_SCOPE.parse().unwrap(),
         EXAMPLE_PASSPHRASE.as_bytes(),
     );

--- a/oxide-auth-iron/examples/iron.rs
+++ b/oxide-auth-iron/examples/iron.rs
@@ -148,7 +148,10 @@ here</a> to begin the authorization process.
             registrar: Mutex::new(
                 vec![Client::public(
                     "LocalClient",
-                    "http://localhost:8021/endpoint".parse().unwrap(),
+                    "http://localhost:8021/endpoint"
+                        .parse::<url::Url>()
+                        .unwrap()
+                        .into(),
                     "default-scope".parse().unwrap(),
                 )]
                 .into_iter()

--- a/oxide-auth-rocket/examples/rocket.rs
+++ b/oxide-auth-rocket/examples/rocket.rs
@@ -15,6 +15,7 @@ use std::sync::Mutex;
 use oxide_auth::endpoint::{OwnerConsent, Solicitation};
 use oxide_auth::frontends::simple::endpoint::{FnSolicitor, Generic, Vacant};
 use oxide_auth::primitives::prelude::*;
+use oxide_auth::primitives::registrar::RegisteredUrl;
 use oxide_auth_rocket::{OAuthResponse, OAuthRequest, OAuthFailure};
 
 use rocket::{Data, State, Response, http};
@@ -124,7 +125,9 @@ impl MyState {
             registrar: Mutex::new(
                 vec![Client::public(
                     "LocalClient",
-                    "http://localhost:8000/clientside/endpoint".parse().unwrap(),
+                    RegisteredUrl::Semantic(
+                        "http://localhost:8000/clientside/endpoint".parse().unwrap(),
+                    ),
                     "default-scope".parse().unwrap(),
                 )]
                 .into_iter()

--- a/oxide-auth-rouille/examples/rouille.rs
+++ b/oxide-auth-rouille/examples/rouille.rs
@@ -23,8 +23,11 @@ pub fn main() {
         let mut clients = ClientMap::new();
         // Register a dummy client instance
         let client = Client::public(
-            "LocalClient",                                     // Client id
-            "http://localhost:8021/endpoint".parse().unwrap(), // Redirection url
+            "LocalClient", // Client id
+            "http://localhost:8021/endpoint"
+                .parse::<url::Url>()
+                .unwrap()
+                .into(), // Redirection url
             "default".parse().unwrap(),
         ); // Allowed client scope
         clients.register_client(client);

--- a/oxide-auth/src/endpoint/tests/access_token.rs
+++ b/oxide-auth/src/endpoint/tests/access_token.rs
@@ -1,7 +1,7 @@
 use primitives::authorizer::{AuthMap, Authorizer};
 use primitives::issuer::TokenMap;
 use primitives::grant::{Grant, Extensions};
-use primitives::registrar::{Client, ClientMap};
+use primitives::registrar::{Client, ClientMap, RegisteredUrl};
 
 use frontends::simple::endpoint::access_token_flow;
 
@@ -30,7 +30,7 @@ impl AccessTokenSetup {
 
         let client = Client::confidential(
             EXAMPLE_CLIENT_ID,
-            EXAMPLE_REDIRECT_URI.parse().unwrap(),
+            RegisteredUrl::Semantic(EXAMPLE_REDIRECT_URI.parse().unwrap()),
             EXAMPLE_SCOPE.parse().unwrap(),
             EXAMPLE_PASSPHRASE.as_bytes(),
         );
@@ -66,7 +66,7 @@ impl AccessTokenSetup {
 
         let client = Client::public(
             EXAMPLE_CLIENT_ID,
-            EXAMPLE_REDIRECT_URI.parse().unwrap(),
+            RegisteredUrl::Semantic(EXAMPLE_REDIRECT_URI.parse().unwrap()),
             EXAMPLE_SCOPE.parse().unwrap(),
         );
 
@@ -198,7 +198,7 @@ fn access_equivalent_url() {
 
     let confusing_client = Client::public(
         CLIENT_ID,
-        REDIRECT_URL.parse().unwrap(),
+        RegisteredUrl::Semantic(REDIRECT_URL.parse().unwrap()),
         EXAMPLE_SCOPE.parse().unwrap(),
     );
 

--- a/oxide-auth/src/endpoint/tests/authorization.rs
+++ b/oxide-auth/src/endpoint/tests/authorization.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use primitives::authorizer::AuthMap;
-use primitives::registrar::{Client, ClientMap};
+use primitives::registrar::{Client, ClientMap, RegisteredUrl};
 
 use endpoint::{OwnerSolicitor};
 
@@ -23,7 +23,7 @@ impl AuthorizationSetup {
 
         let client = Client::confidential(
             EXAMPLE_CLIENT_ID,
-            EXAMPLE_REDIRECT_URI.parse().unwrap(),
+            RegisteredUrl::Semantic(EXAMPLE_REDIRECT_URI.parse().unwrap()),
             EXAMPLE_SCOPE.parse().unwrap(),
             EXAMPLE_PASSPHRASE.as_bytes(),
         );

--- a/oxide-auth/src/endpoint/tests/pkce.rs
+++ b/oxide-auth/src/endpoint/tests/pkce.rs
@@ -1,7 +1,7 @@
 use primitives::authorizer::AuthMap;
 use primitives::issuer::TokenMap;
 use primitives::generator::RandomGenerator;
-use primitives::registrar::{Client, ClientMap};
+use primitives::registrar::{Client, ClientMap, RegisteredUrl};
 
 use code_grant::accesstoken::TokenResponse;
 use endpoint::{AuthorizationFlow, AccessTokenFlow, Endpoint};
@@ -26,7 +26,7 @@ impl PkceSetup {
     fn new() -> PkceSetup {
         let client = Client::public(
             EXAMPLE_CLIENT_ID,
-            EXAMPLE_REDIRECT_URI.parse().unwrap(),
+            RegisteredUrl::Semantic(EXAMPLE_REDIRECT_URI.parse().unwrap()),
             EXAMPLE_SCOPE.parse().unwrap(),
         );
 

--- a/oxide-auth/src/endpoint/tests/refresh.rs
+++ b/oxide-auth/src/endpoint/tests/refresh.rs
@@ -1,7 +1,7 @@
 use primitives::issuer::{Issuer, IssuedToken, RefreshedToken, TokenMap};
 use primitives::generator::RandomGenerator;
 use primitives::grant::{Grant, Extensions};
-use primitives::registrar::{Client, ClientMap};
+use primitives::registrar::{Client, ClientMap, RegisteredUrl};
 
 use std::collections::HashMap;
 
@@ -33,7 +33,7 @@ impl RefreshTokenSetup {
 
         let client = Client::confidential(
             EXAMPLE_CLIENT_ID,
-            EXAMPLE_REDIRECT_URI.parse().unwrap(),
+            RegisteredUrl::Semantic(EXAMPLE_REDIRECT_URI.parse().unwrap()),
             EXAMPLE_SCOPE.parse().unwrap(),
             EXAMPLE_PASSPHRASE.as_bytes(),
         );
@@ -71,7 +71,7 @@ impl RefreshTokenSetup {
 
         let client = Client::public(
             EXAMPLE_CLIENT_ID,
-            EXAMPLE_REDIRECT_URI.parse().unwrap(),
+            RegisteredUrl::Exact(EXAMPLE_REDIRECT_URI.parse().unwrap()),
             EXAMPLE_SCOPE.parse().unwrap(),
         );
 
@@ -247,7 +247,7 @@ fn public_private_invalid_grant() {
     let mut setup = RefreshTokenSetup::public_client();
     let client = Client::confidential(
         "PrivateClient".into(),
-        EXAMPLE_REDIRECT_URI.parse().unwrap(),
+        RegisteredUrl::Semantic(EXAMPLE_REDIRECT_URI.parse().unwrap()),
         EXAMPLE_SCOPE.parse().unwrap(),
         EXAMPLE_PASSPHRASE.as_bytes(),
     );


### PR DESCRIPTION
This fixes #68 

 - [x] This change has tests (remove for doc only)
 - [x] This change has documentation
 - [x] Corresponds to issue #68 
