### PR TITLE
Implement token rotation for `TokenMap`

### DIFF
--- a/oxide-auth/src/primitives/issuer.rs
+++ b/oxide-auth/src/primitives/issuer.rs
@@ -635,6 +635,23 @@ pub mod tests {
     }
 
     #[test]
+    fn random_refresh_rotation() {
+        let mut token_map = TokenMap::new(RandomGenerator::new(16));
+        let issued = token_map.issue(grant_template());
+
+        let token = issued.expect("Issuing with refresh token failed");
+        let refresh = token.refresh.expect("No refresh token returned");
+
+        let refreshed_token = token_map
+            .refresh(&refresh, grant_template())
+            .expect("Failed to refresh access token");
+
+        let new_refresh = refreshed_token.refresh.expect("No new refresh token returned");
+
+        assert!(refresh != new_refresh);
+    }
+
+    #[test]
     #[should_panic]
     fn bad_generator() {
         struct BadGenerator;

--- a/oxide-auth/src/primitives/issuer.rs
+++ b/oxide-auth/src/primitives/issuer.rs
@@ -287,10 +287,11 @@ impl<G: TagGrant> Issuer for TokenMap<G> {
         self.set_duration(&mut grant);
         let until = grant.until;
 
-        let next_usage = self.usage.wrapping_add(2);
+        let tag = self.usage;
+        let new_access = self.generator.tag(tag, &grant)?;
 
-        let new_access = self.generator.tag(self.usage, &grant)?;
-        let new_refresh = self.generator.tag(self.usage.wrapping_add(1), &grant)?;
+        let tag = tag.wrapping_add(1);
+        let new_refresh = self.generator.tag(tag, &grant)?;
 
         let new_access_key: Arc<str> = Arc::from(new_access.clone());
         let new_refresh_key: Arc<str> = Arc::from(new_refresh.clone());
@@ -312,7 +313,7 @@ impl<G: TagGrant> Issuer for TokenMap<G> {
         self.access.insert(new_access_key, token.clone());
         self.refresh.insert(new_refresh_key, token);
 
-        self.usage = next_usage;
+        self.usage = tag.wrapping_add(1);
         Ok(RefreshedToken {
             token: new_access,
             refresh: Some(new_refresh),


### PR DESCRIPTION
This improves the security of the token refresh flow for the `TokenMap` primitive by returning a new refresh token every time, invalidating the previous one.

As mentioned here: https://datatracker.ietf.org/doc/html/rfc6819#section-5.2.2.3