### PR TITLE
Add serde_urlencoded to db-example Cargo.toml

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,12 +1,6 @@
 stable_task:
   container:
     image: rust:latest
-  additional_containers:
-    - name: redis
-      image: redis:latest
-      port: 6379
-      cpu: 1.0
-      memory: 128Mi
   cargo_cache:
     folder: $CARGO_HOME/registry
     fingerprint_script: cargo update && cat Cargo.lock
@@ -27,12 +21,6 @@ stable_task:
 nightly_task:
   container:
     image: rustlang/rust:nightly
-  additional_containers:
-    - name: redis
-      image: redis:latest
-      port: 6379
-      cpu: 1.0
-      memory: 128Mi
   cargo_cache:
     folder: $CARGO_HOME/registry
     fingerprint_script: cargo update && cat Cargo.lock

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,6 +12,8 @@ stable_task:
       - CRATE: actix-example
       - CRATE: oxide-auth-iron
       - CRATE: oxide-auth-rouille
+      - CRATE: oxide-auth-db
+      - CRATE: db-example
   build_script: cargo build -p "$CRATE" --examples
   test_script: cargo test -p "$CRATE"
   before_cache_script: rm -rf $CARGO_HOME/registry/index
@@ -31,6 +33,8 @@ nightly_task:
       - CRATE: oxide-auth-iron
       - CRATE: oxide-auth-rouille
       - CRATE: oxide-auth-rocket
+      - CRATE: oxide-auth-db
+      - CRATE: db-example
   build_script: cargo build -p "$CRATE" --examples
   test_script: cargo test -p "$CRATE"
   before_cache_script: rm -rf $CARGO_HOME/registry/index

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,6 +13,7 @@ stable_task:
       - CRATE: oxide-auth-iron
       - CRATE: oxide-auth-rouille
       - CRATE: oxide-auth-db
+        OXIDE_AUTH_SKIP_REDIS: yes
       - CRATE: db-example
   build_script: cargo build -p "$CRATE" --examples
   test_script: cargo test -p "$CRATE"
@@ -34,6 +35,7 @@ nightly_task:
       - CRATE: oxide-auth-rouille
       - CRATE: oxide-auth-rocket
       - CRATE: oxide-auth-db
+        OXIDE_AUTH_SKIP_REDIS: yes
       - CRATE: db-example
   build_script: cargo build -p "$CRATE" --examples
   test_script: cargo test -p "$CRATE"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,6 +1,12 @@
 stable_task:
   container:
     image: rust:latest
+  additional_containers:
+    - name: redis
+      image: redis:latest
+      port: 6379
+      cpu: 1.0
+      memory: 128Mi
   cargo_cache:
     folder: $CARGO_HOME/registry
     fingerprint_script: cargo update && cat Cargo.lock
@@ -21,6 +27,12 @@ stable_task:
 nightly_task:
   container:
     image: rustlang/rust:nightly
+  additional_containers:
+    - name: redis
+      image: redis:latest
+      port: 6379
+      cpu: 1.0
+      memory: 128Mi
   cargo_cache:
     folder: $CARGO_HOME/registry
     fingerprint_script: cargo update && cat Cargo.lock

--- a/oxide-auth-db/Cargo.toml
+++ b/oxide-auth-db/Cargo.toml
@@ -16,7 +16,6 @@ rand = "0.7.3"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-serde_urlencoded = "0.7.0"
 rust-argon2 = "0.8.2"
 r2d2 = {version ="0.8", optional = true }
 r2d2_redis = {version = "0.13", optional = true }

--- a/oxide-auth-db/Cargo.toml
+++ b/oxide-auth-db/Cargo.toml
@@ -16,6 +16,7 @@ rand = "0.7.3"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
+serde_urlencoded = "0.7.0"
 rust-argon2 = "0.8.2"
 r2d2 = {version ="0.8", optional = true }
 r2d2_redis = {version = "0.13", optional = true }

--- a/oxide-auth-db/examples/db-example/Cargo.toml
+++ b/oxide-auth-db/examples/db-example/Cargo.toml
@@ -1,11 +1,10 @@
 [package]
 name = "db-example"
-version = "0.1.0"
+version = "0.0.0"
 authors = ["liujing <liujingb@mail.taiji.com.cn>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+publish = false
 
 [dependencies]
 oxide-auth = { version = "0.5.0-preview.0", path = "../../../oxide-auth" }

--- a/oxide-auth-db/examples/db-example/Cargo.toml
+++ b/oxide-auth-db/examples/db-example/Cargo.toml
@@ -19,6 +19,7 @@ futures = "0.3"
 reqwest = "=0.9.5"
 serde = "1.0"
 serde_json = "1.0"
+serde_urlencoded = "^0.7"
 url = "2"
 anyhow = "1.0"
 r2d2_redis = {version = "0.13"}

--- a/oxide-auth-db/src/lib.rs
+++ b/oxide-auth-db/src/lib.rs
@@ -3,3 +3,14 @@ extern crate serde_derive;
 
 pub mod db_service;
 pub mod primitives;
+
+#[cfg(test)]
+fn requires_redis_and_should_skip() -> bool {
+    match std::env::var("OXIDE_AUTH_SKIP_REDIS") {
+        Err(_) => false,
+        Ok(st) => match st.as_str() {
+            "1" | "yes" => true,
+            _ => false,
+        },
+    }
+}

--- a/oxide-auth-db/src/primitives/db_registrar.rs
+++ b/oxide-auth-db/src/primitives/db_registrar.rs
@@ -177,6 +177,10 @@ mod tests {
 
     #[test]
     fn with_additional_redirect_uris() {
+        if crate::requires_redis_and_should_skip() {
+            return;
+        }
+
         let client_id = "ClientId";
         let redirect_uri =
             RegisteredUrl::from(ExactUrl::new("https://example.com/foo".parse().unwrap()).unwrap());
@@ -230,6 +234,10 @@ mod tests {
 
     #[test]
     fn client_service() {
+        if crate::requires_redis_and_should_skip() {
+            return;
+        }
+
         let mut oauth_service = DBRegistrar::new(
             "redis://localhost/3".parse().unwrap(),
             32,


### PR DESCRIPTION
No real changes, just added serde_urlencoded to the db-example sub-project

I license past and future contributions under the dual MIT/Apache-2.0 license, allowing licensees to chose either at their option.

[Contributing]: CONTRIBUTING.md
