### PR TITLE
Derive Serialize/Deserialize for `EncodedClient`

### DIFF
--- a/oxide-auth/Cargo.toml
+++ b/oxide-auth/Cargo.toml
@@ -27,7 +27,7 @@ subtle = "2.4.1"
 rand = "0.8"
 rust-argon2 = "0.8.3"
 rmp-serde = "0.15"
-url = "2.2.2"
+url = { version = "2.2.2", features = ["serde"] }
 
 [dev-dependencies]
 reqwest = "0.10.8"

--- a/oxide-auth/src/primitives/registrar.rs
+++ b/oxide-auth/src/primitives/registrar.rs
@@ -100,7 +100,7 @@ impl<'de> Deserialize<'de> for ExactUrl {
     where
         D: serde::Deserializer<'de>,
     {
-        let string = String::deserialize(deserializer)?;
+        let string: &str = Deserialize::deserialize(deserializer)?;
         core::str::FromStr::from_str(&string).map_err(serde::de::Error::custom)
     }
 }
@@ -145,8 +145,8 @@ impl<'de> Deserialize<'de> for IgnoreLocalPortUrl {
     where
         D: serde::Deserializer<'de>,
     {
-        let string = String::deserialize(deserializer)?;
-        Self::new(&string).map_err(serde::de::Error::custom)
+        let string: &str = Deserialize::deserialize(deserializer)?;
+        Self::new(string).map_err(serde::de::Error::custom)
     }
 }
 

--- a/oxide-auth/src/primitives/registrar.rs
+++ b/oxide-auth/src/primitives/registrar.rs
@@ -16,6 +16,7 @@ use std::sync::{Arc, MutexGuard, RwLockWriteGuard};
 use argon2::{self, Config};
 use once_cell::sync::Lazy;
 use rand::{RngCore, thread_rng};
+use serde::{Deserialize, Serialize};
 use url::{Url, ParseError as ParseUrlError};
 
 /// Registrars provie a way to interact with clients.
@@ -52,7 +53,7 @@ pub trait Registrar {
 /// 1. By supplying a string to match _exactly_
 /// 2. By an URL which needs to match semantically.
 #[non_exhaustive]
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum RegisteredUrl {
     /// An exact URL that must be match literally when the client uses it.
     ///
@@ -91,7 +92,7 @@ pub enum RegisteredUrl {
 /// possible if clients are allowed to provide any semantically matching URL as there are
 /// infinitely many with different hashes. (Note: a hashed form of URL storage is not currently
 /// supported).
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ExactUrl(String);
 
 /// A redirect URL that ignores port where host is `localhost`.
@@ -120,10 +121,10 @@ pub struct ExactUrl(String);
 /// considered.
 ///
 /// [`ExactUrl`]: ExactUrl
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct IgnoreLocalPortUrl(IgnoreLocalPortUrlInternal);
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 enum IgnoreLocalPortUrlInternal {
     Exact(String),
     Local(Url),
@@ -214,7 +215,7 @@ pub struct Client {
 ///
 /// This provides a standard encoding for `Registrars` who wish to store their clients and makes it
 /// possible to test password policies.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct EncodedClient {
     /// The id of this client. If this is was registered at a `Registrar`, this should be a key
     /// to the instance.
@@ -243,7 +244,7 @@ pub struct RegisteredClient<'a> {
 }
 
 /// Enumeration of the two defined client types.
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
 pub enum ClientType {
     /// A public client with no authentication information.
     Public,

--- a/oxide-auth/src/primitives/registrar.rs
+++ b/oxide-auth/src/primitives/registrar.rs
@@ -92,8 +92,18 @@ pub enum RegisteredUrl {
 /// possible if clients are allowed to provide any semantically matching URL as there are
 /// infinitely many with different hashes. (Note: a hashed form of URL storage is not currently
 /// supported).
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct ExactUrl(String);
+
+impl<'de> Deserialize<'de> for ExactUrl {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let string = String::deserialize(deserializer)?;
+        core::str::FromStr::from_str(&string).map_err(serde::de::Error::custom)
+    }
+}
 
 /// A redirect URL that ignores port where host is `localhost`.
 ///
@@ -121,13 +131,23 @@ pub struct ExactUrl(String);
 /// considered.
 ///
 /// [`ExactUrl`]: ExactUrl
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct IgnoreLocalPortUrl(IgnoreLocalPortUrlInternal);
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 enum IgnoreLocalPortUrlInternal {
     Exact(String),
     Local(Url),
+}
+
+impl<'de> Deserialize<'de> for IgnoreLocalPortUrl {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let string = String::deserialize(deserializer)?;
+        Self::new(&string).map_err(serde::de::Error::custom)
+    }
 }
 
 /// A pair of `client_id` and an optional `redirect_uri`.

--- a/oxide-auth/src/primitives/scope.rs
+++ b/oxide-auth/src/primitives/scope.rs
@@ -44,9 +44,28 @@ use serde::{Deserialize, Serialize};
 ///
 /// In particular, the characters '\x22' (`"`) and '\x5c' (`\`)  are not allowed.
 ///
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct Scope {
     tokens: HashSet<String>,
+}
+
+impl Serialize for Scope {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for Scope {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let string = String::deserialize(deserializer)?;
+        core::str::FromStr::from_str(&string).map_err(serde::de::Error::custom)
+    }
 }
 
 impl Scope {

--- a/oxide-auth/src/primitives/scope.rs
+++ b/oxide-auth/src/primitives/scope.rs
@@ -2,6 +2,7 @@
 use std::{cmp, fmt, str};
 
 use std::collections::HashSet;
+use serde::{Deserialize, Serialize};
 
 /// Scope of a given grant or resource, a set of scope-tokens separated by spaces.
 ///
@@ -43,7 +44,7 @@ use std::collections::HashSet;
 ///
 /// In particular, the characters '\x22' (`"`) and '\x5c' (`\`)  are not allowed.
 ///
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Scope {
     tokens: HashSet<String>,
 }

--- a/oxide-auth/src/primitives/scope.rs
+++ b/oxide-auth/src/primitives/scope.rs
@@ -63,8 +63,8 @@ impl<'de> Deserialize<'de> for Scope {
     where
         D: serde::Deserializer<'de>,
     {
-        let string = String::deserialize(deserializer)?;
-        core::str::FromStr::from_str(&string).map_err(serde::de::Error::custom)
+        let string: &str = Deserialize::deserialize(deserializer)?;
+        core::str::FromStr::from_str(string).map_err(serde::de::Error::custom)
     }
 }
 

--- a/oxide-auth/src/primitives/scope.rs
+++ b/oxide-auth/src/primitives/scope.rs
@@ -225,4 +225,20 @@ mod tests {
         assert!(all.contains(&"cap2"));
         assert!(all.contains(&"cap3"));
     }
+
+    #[test]
+    fn deserialize_invalid_scope() {
+        let scope = "\x22";
+        let serialized = rmp_serde::to_vec(&scope).unwrap();
+        let deserialized = rmp_serde::from_slice::<Scope>(&serialized);
+        assert!(deserialized.is_err());
+    }
+
+    #[test]
+    fn roundtrip_serialization_scope() {
+        let scope = "cap1 cap2 cap3".parse::<Scope>().unwrap();
+        let serialized = rmp_serde::to_vec(&scope).unwrap();
+        let deserialized = rmp_serde::from_slice::<Scope>(&serialized).unwrap();
+        assert_eq!(scope, deserialized);
+    }
 }


### PR DESCRIPTION
This adds support for custom implementations of `Registrar` to store encoded clients in a serialized format of choice.

-----------------------------------

 - [x] I have read the [contribution guidelines][Contributing]

I license past and future contributions under the dual MIT/Apache-2.0 license, allowing licensees to chose either at their option.


[Contributing]: CONTRIBUTING.md
