### PR TITLE
Add forgotten Readme.md for oxide-auth-poem

### DIFF
--- a/oxide-auth-poem/Readme.md
+++ b/oxide-auth-poem/Readme.md
@@ -4,7 +4,7 @@ Integrates `oxide-auth` with the [`poem`] web server library.
 
 ## Additional
 
-[![Crates.io Status](https://img.shields.io/crates/v/oxide-auth-iron.svg)](https://crates.io/crates/oxide-auth-iron)
+[![Crates.io Status](https://img.shields.io/crates/v/oxide-auth-poem.svg)](https://crates.io/crates/oxide-auth-poem)
 [![Docs.rs Status](https://docs.rs/oxide-auth-iron/badge.svg)](https://docs.rs/oxide-auth-iron/)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/HeroicKatora/oxide-auth/dev-v0.4.0/docs/LICENSE-MIT)
 [![License](https://img.shields.io/badge/license-Apache-blue.svg)](https://raw.githubusercontent.com/HeroicKatora/oxide-auth/dev-v0.4.0/docs/LICENSE-APACHE)

--- a/oxide-auth-poem/Readme.md
+++ b/oxide-auth-poem/Readme.md
@@ -1,0 +1,20 @@
+# oxide-auth-poem
+
+Integrates `oxide-auth` with the [`poem`] web server library.
+
+## Additional
+
+[![Crates.io Status](https://img.shields.io/crates/v/oxide-auth-iron.svg)](https://crates.io/crates/oxide-auth-iron)
+[![Docs.rs Status](https://docs.rs/oxide-auth-iron/badge.svg)](https://docs.rs/oxide-auth-iron/)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/HeroicKatora/oxide-auth/dev-v0.4.0/docs/LICENSE-MIT)
+[![License](https://img.shields.io/badge/license-Apache-blue.svg)](https://raw.githubusercontent.com/HeroicKatora/oxide-auth/dev-v0.4.0/docs/LICENSE-APACHE)
+[![CI Status](https://api.cirrus-ci.com/github/HeroicKatora/oxide-auth.svg)](https://cirrus-ci.com/github/HeroicKatora/oxide-auth)
+
+Licensed under either of
+* MIT license ([LICENSE-MIT] or http://opensource.org/licenses/MIT)
+* Apache License, Version 2.0 ([LICENSE-APACHE] or http://www.apache.org/licenses/LICENSE-2.0)
+  at your option.
+
+[`iron`]: https://crates.io/crates/poem
+[LICENSE-MIT]: docs/LICENSE-MIT
+[LICENSE-APACHE]: docs/LICENSE-APACHE

--- a/oxide-auth-poem/Readme.md
+++ b/oxide-auth-poem/Readme.md
@@ -15,6 +15,6 @@ Licensed under either of
 * Apache License, Version 2.0 ([LICENSE-APACHE] or http://www.apache.org/licenses/LICENSE-2.0)
   at your option.
 
-[`iron`]: https://crates.io/crates/poem
+[`poem`]: https://crates.io/crates/poem
 [LICENSE-MIT]: docs/LICENSE-MIT
 [LICENSE-APACHE]: docs/LICENSE-APACHE


### PR DESCRIPTION
This changes/fixes/improves #138;

 - [x] I have read the [contribution guidelines][Contributing]
 - [x] This change has documentation
 - [x] Corresponds to issue #138

I license past and future contributions under the dual MIT/Apache-2.0 license, allowing licensees to chose either at their option.

We have to do this so I can publish without doing `--allow-dirty`.