### PR TITLE
Fix clippy warnings

### DIFF
--- a/oxide-auth-actix/Cargo.toml
+++ b/oxide-auth-actix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxide-auth-actix"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Andreas Molzer <andreas.molzer@gmx.de>"]
 repository = "https://github.com/HeroicKatora/oxide-auth.git"
 
@@ -15,7 +15,7 @@ edition = "2018"
 actix = { version = "0.12", default-features = false }
 actix-web = { version = "4.0.1", default-features = false }
 futures = "0.3"
-oxide-auth = { version = "0.5.0", path = "../oxide-auth" }
+oxide-auth = { version = "0.6", path = "../oxide-auth" }
 serde_urlencoded = "0.7"
 url = "2"
 

--- a/oxide-auth-actix/Changes.md
+++ b/oxide-auth-actix/Changes.md
@@ -1,3 +1,7 @@
+## 0.3.0
+- Fixed clippy errors
+- Turned some `Into` implementations into `From` implementations 
+
 ## 0.2.0
 
 - Now compatible to `actix = "4"`.

--- a/oxide-auth-actix/examples/actix-example/Cargo.toml
+++ b/oxide-auth-actix/examples/actix-example/Cargo.toml
@@ -10,7 +10,7 @@ actix-web = "4.0.1"
 env_logger = "0.7"
 futures = "0.3"
 oxide-auth = { version = "0.5.0", path = "./../../../oxide-auth" }
-oxide-auth-actix = { version = "0.2.0", path = "./../../" }
+oxide-auth-actix = { version = "0.2.0", path = "./../../../oxide-auth-actix" }
 reqwest = "=0.9.5"
 serde = "1.0"
 serde_json = "1.0"

--- a/oxide-auth-actix/examples/actix-example/Cargo.toml
+++ b/oxide-auth-actix/examples/actix-example/Cargo.toml
@@ -9,8 +9,8 @@ actix = "0.12"
 actix-web = "4.0.1"
 env_logger = "0.7"
 futures = "0.3"
-oxide-auth = { version = "0.5.0", path = "./../../../oxide-auth" }
-oxide-auth-actix = { version = "0.2.0", path = "./../../../oxide-auth-actix" }
+oxide-auth = { version = "0.6", path = "./../../../oxide-auth" }
+oxide-auth-actix = { version = "0.3.0", path = "./../../../oxide-auth-actix" }
 reqwest = "=0.9.5"
 serde = "1.0"
 serde_json = "1.0"

--- a/oxide-auth-async/Cargo.toml
+++ b/oxide-auth-async/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxide-auth-async"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Andreas Molzer <andreas.molzer@gmx.de>"]
 repository = "https://github.com/HeroicKatora/oxide-auth.git"
 
@@ -13,7 +13,7 @@ edition = "2018"
 
 [dependencies]
 async-trait = "0.1.21"
-oxide-auth = { version = "0.5.0", path = "../oxide-auth" }
+oxide-auth = { version = "0.6", path = "../oxide-auth" }
 base64 = "0.12"
 url = "2"
 chrono = "0.4.2"

--- a/oxide-auth-async/Cargo.toml
+++ b/oxide-auth-async/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxide-auth-async"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Andreas Molzer <andreas.molzer@gmx.de>"]
 repository = "https://github.com/HeroicKatora/oxide-auth.git"
 

--- a/oxide-auth-async/src/code_grant.rs
+++ b/oxide-auth-async/src/code_grant.rs
@@ -131,7 +131,7 @@ pub mod resource {
 pub mod access_token {
     use async_trait::async_trait;
     use oxide_auth::{
-        code_grant::accesstoken::{
+        code_grant::access_token::{
             AccessToken, BearerToken, Error, Input, Output, PrimitiveError, Request as TokenRequest,
         },
         primitives::{

--- a/oxide-auth-async/src/endpoint/access_token.rs
+++ b/oxide-auth-async/src/endpoint/access_token.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, marker::PhantomData};
 
 use oxide_auth::{
     endpoint::{QueryParameter, WebRequest, OAuthError, WebResponse, Template, NormalizedParameter},
-    code_grant::accesstoken::{Error as TokenError, Request as TokenRequest},
+    code_grant::access_token::{Error as TokenError, Request as TokenRequest},
 };
 
 use super::Endpoint;

--- a/oxide-auth-async/src/endpoint/authorization.rs
+++ b/oxide-auth-async/src/endpoint/authorization.rs
@@ -5,8 +5,11 @@ use oxide_auth::{
     code_grant::authorization::{Error as AuthorizationError, Request as AuthorizationRequest},
 };
 
-use crate::code_grant::authorization::{
-    authorization_code, Endpoint as AuthorizationEndpoint, Extension, Pending,
+use crate::{
+    code_grant::authorization::{
+        authorization_code, Endpoint as AuthorizationEndpoint, Extension, Pending,
+    },
+    endpoint::OwnerSolicitor,
 };
 
 use super::*;
@@ -65,7 +68,7 @@ where
     inner: AuthorizationPartialInner<'a, E, R>,
 
     /// TODO: offer this in the public api instead of dropping the request.
-    _with_request: Option<Box<dyn FnOnce(R) -> () + Send>>,
+    _with_request: Option<Box<dyn FnOnce(R) + Send>>,
 }
 
 /// Result type from processing an authentication request.

--- a/oxide-auth-async/src/endpoint/refresh.rs
+++ b/oxide-auth-async/src/endpoint/refresh.rs
@@ -213,18 +213,18 @@ impl<R: WebRequest> Request for WrappedRequest<R> {
         self.body.unique_value("refresh_token")
     }
 
-    fn authorization(&self) -> Option<(Cow<str>, Cow<[u8]>)> {
-        self.authorization
-            .as_ref()
-            .map(|auth| (auth.0.as_str().into(), auth.1.as_slice().into()))
-    }
-
     fn scope(&self) -> Option<Cow<str>> {
         self.body.unique_value("scope")
     }
 
     fn grant_type(&self) -> Option<Cow<str>> {
         self.body.unique_value("grant_type")
+    }
+
+    fn authorization(&self) -> Option<(Cow<str>, Cow<[u8]>)> {
+        self.authorization
+            .as_ref()
+            .map(|auth| (auth.0.as_str().into(), auth.1.as_slice().into()))
     }
 
     fn extension(&self, key: &str) -> Option<Cow<str>> {

--- a/oxide-auth-async/src/tests/authorization.rs
+++ b/oxide-auth-async/src/tests/authorization.rs
@@ -44,6 +44,9 @@ impl<'a> Endpoint<CraftedRequest> for AuthorizationEndpoint<'a> {
     fn issuer_mut(&mut self) -> Option<&mut (dyn crate::primitives::Issuer + Send)> {
         None
     }
+    fn owner_solicitor(&mut self) -> Option<&mut (dyn OwnerSolicitor<CraftedRequest> + Send)> {
+        Some(self.solicitor)
+    }
     fn scopes(&mut self) -> Option<&mut dyn oxide_auth::endpoint::Scopes<CraftedRequest>> {
         None
     }
@@ -57,9 +60,6 @@ impl<'a> Endpoint<CraftedRequest> for AuthorizationEndpoint<'a> {
     }
     fn web_error(&mut self, err: <CraftedRequest as WebRequest>::Error) -> Self::Error {
         Error::Web(err)
-    }
-    fn owner_solicitor(&mut self) -> Option<&mut (dyn OwnerSolicitor<CraftedRequest> + Send)> {
-        Some(self.solicitor)
     }
 }
 
@@ -89,7 +89,7 @@ impl AuthorizationSetup {
     fn test_success(&mut self, request: CraftedRequest) {
         let mut solicitor = Allow(EXAMPLE_OWNER_ID.to_string());
         let mut authorization_flow = AuthorizationFlow::prepare(AuthorizationEndpoint::new(
-            &mut self.registrar,
+            &self.registrar,
             &mut self.authorizer,
             &mut solicitor,
         ))
@@ -107,7 +107,7 @@ impl AuthorizationSetup {
     fn test_silent_error(&mut self, request: CraftedRequest) {
         let mut solicitor = Allow(EXAMPLE_OWNER_ID.to_string());
         let mut authorization_flow = AuthorizationFlow::prepare(AuthorizationEndpoint::new(
-            &mut self.registrar,
+            &self.registrar,
             &mut self.authorizer,
             &mut solicitor,
         ))

--- a/oxide-auth-async/src/tests/mod.rs
+++ b/oxide-auth-async/src/tests/mod.rs
@@ -77,8 +77,8 @@ enum CraftedError {
 }
 
 impl WebRequest for CraftedRequest {
-    type Response = CraftedResponse;
     type Error = CraftedError;
+    type Response = CraftedResponse;
 
     fn query(&mut self) -> Result<Cow<dyn QueryParameter + 'static>, Self::Error> {
         self.query

--- a/oxide-auth-async/src/tests/refresh.rs
+++ b/oxide-auth-async/src/tests/refresh.rs
@@ -2,7 +2,7 @@ use oxide_auth::primitives::issuer::{IssuedToken, RefreshedToken, TokenMap, Toke
 use oxide_auth::primitives::generator::RandomGenerator;
 use oxide_auth::primitives::grant::{Grant, Extensions};
 use oxide_auth::{
-    code_grant::accesstoken::TokenResponse,
+    code_grant::access_token::TokenResponse,
     endpoint::{WebRequest},
     primitives::registrar::{Client, ClientMap, RegisteredUrl},
     frontends::simple::endpoint::Error,
@@ -45,6 +45,14 @@ impl<'a> Endpoint<CraftedRequest> for RefreshTokenEndpoint<'a> {
     fn issuer_mut(&mut self) -> Option<&mut (dyn crate::primitives::Issuer + Send)> {
         Some(self.issuer)
     }
+    fn owner_solicitor(
+        &mut self,
+    ) -> Option<&mut (dyn crate::endpoint::OwnerSolicitor<CraftedRequest> + Send)> {
+        None
+    }
+    fn scopes(&mut self) -> Option<&mut dyn oxide_auth::endpoint::Scopes<CraftedRequest>> {
+        None
+    }
     fn response(
         &mut self, _: &mut CraftedRequest, _: oxide_auth::endpoint::Template,
     ) -> Result<<CraftedRequest as WebRequest>::Response, Self::Error> {
@@ -55,14 +63,6 @@ impl<'a> Endpoint<CraftedRequest> for RefreshTokenEndpoint<'a> {
     }
     fn web_error(&mut self, _err: <CraftedRequest as WebRequest>::Error) -> Self::Error {
         unimplemented!()
-    }
-    fn scopes(&mut self) -> Option<&mut dyn oxide_auth::endpoint::Scopes<CraftedRequest>> {
-        None
-    }
-    fn owner_solicitor(
-        &mut self,
-    ) -> Option<&mut (dyn crate::endpoint::OwnerSolicitor<CraftedRequest> + Send)> {
-        None
     }
 }
 
@@ -139,7 +139,7 @@ impl RefreshTokenSetup {
         assert!(issued.refreshable());
         let refresh_token = issued.refresh.clone().unwrap();
 
-        let basic_authorization = "DO_NOT_USE".into();
+        let basic_authorization = "DO_NOT_USE".to_string();
 
         RefreshTokenSetup {
             registrar,

--- a/oxide-auth-async/src/tests/resource.rs
+++ b/oxide-auth-async/src/tests/resource.rs
@@ -26,6 +26,14 @@ impl<'a> Endpoint<CraftedRequest> for ResourceEndpoint<'a> {
     fn issuer_mut(&mut self) -> Option<&mut (dyn crate::primitives::Issuer + Send)> {
         Some(self.issuer)
     }
+    fn owner_solicitor(
+        &mut self,
+    ) -> Option<&mut (dyn crate::endpoint::OwnerSolicitor<CraftedRequest> + Send)> {
+        None
+    }
+    fn scopes(&mut self) -> Option<&mut dyn oxide_auth::endpoint::Scopes<CraftedRequest>> {
+        Some(&mut self.scopes)
+    }
     fn response(
         &mut self, _: &mut CraftedRequest, _: oxide_auth::endpoint::Template,
     ) -> Result<<CraftedRequest as WebRequest>::Response, Self::Error> {
@@ -36,14 +44,6 @@ impl<'a> Endpoint<CraftedRequest> for ResourceEndpoint<'a> {
     }
     fn web_error(&mut self, _err: <CraftedRequest as WebRequest>::Error) -> Self::Error {
         unimplemented!()
-    }
-    fn scopes(&mut self) -> Option<&mut dyn oxide_auth::endpoint::Scopes<CraftedRequest>> {
-        Some(&mut self.scopes)
-    }
-    fn owner_solicitor(
-        &mut self,
-    ) -> Option<&mut (dyn crate::endpoint::OwnerSolicitor<CraftedRequest> + Send)> {
-        None
     }
 }
 

--- a/oxide-auth-axum/Cargo.toml
+++ b/oxide-auth-axum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxide-auth-axum"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Daniel Alvsåker <daniel.alvsaaker@protonmail.com>"]
 repository = "https://github.com/HeroicKatora/oxide-auth.git"
 

--- a/oxide-auth-axum/Cargo.toml
+++ b/oxide-auth-axum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxide-auth-axum"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Daniel Alvsåker <daniel.alvsaaker@protonmail.com>"]
 repository = "https://github.com/HeroicKatora/oxide-auth.git"
 
@@ -13,4 +13,4 @@ edition = "2021"
 
 [dependencies]
 axum = "0.5"
-oxide-auth = { version = "0.5", path = "../oxide-auth" }
+oxide-auth = { version = "0.6", path = "../oxide-auth" }

--- a/oxide-auth-axum/src/response.rs
+++ b/oxide-auth-axum/src/response.rs
@@ -9,7 +9,7 @@ use axum::{
 use oxide_auth::frontends::dev::{WebResponse, Url};
 
 #[derive(Default, Clone, Debug)]
-/// Type implementing `WebResponse` and `IntoResponse` for use in route handlers
+/// Type implementing [`WebResponse`] and [`IntoResponse`] for use in route handlers
 pub struct OAuthResponse {
     status: StatusCode,
     headers: HeaderMap,
@@ -17,7 +17,7 @@ pub struct OAuthResponse {
 }
 
 impl OAuthResponse {
-    /// Set the `ContentType` header on a response
+    /// Set the [`ContentType`] header on a response
     pub fn content_type(mut self, content_type: &str) -> Result<Self, WebError> {
         self.headers
             .insert(header::CONTENT_TYPE, content_type.try_into()?);

--- a/oxide-auth-db/Cargo.toml
+++ b/oxide-auth-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxide-auth-db"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["liujing <liujingb@mail.taiji.com.cn>"]
 repository = "https://github.com/HeroicKatora/oxide-auth.git"
 description = "An implement of DB registrar with configurable databases."
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]
-oxide-auth = { version = "0.5.1", path = "../oxide-auth" }
+oxide-auth = { version = "0.6", path = "../oxide-auth" }
 once_cell = "1.3.1"
 rand = "0.7.3"
 serde = "1.0"

--- a/oxide-auth-db/examples/db-example/Cargo.toml
+++ b/oxide-auth-db/examples/db-example/Cargo.toml
@@ -7,9 +7,9 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-oxide-auth = { version = "0.5.1", path = "../../../oxide-auth" }
-oxide-auth-actix = { version = "0.2.0", path = "./../../../oxide-auth-actix" }
-oxide-auth-db = { version = "0.1.0", path = "./../../"}
+oxide-auth = { version = "0.6", path = "../../../oxide-auth" }
+oxide-auth-actix = { version = "0.3.0", path = "./../../../oxide-auth-actix" }
+oxide-auth-db = { version = "0.2.0", path = "./../../"}
 actix = "0.12"
 actix-web = "4.0.1"
 env_logger = "0.7"

--- a/oxide-auth-db/src/db_service/redis.rs
+++ b/oxide-auth-db/src/db_service/redis.rs
@@ -148,7 +148,7 @@ impl OauthClientDBRepository for RedisDataSource {
         let mut r = self.pool.get()?;
         let client_str = r.get::<&str, String>(&(self.client_prefix.to_owned() + id))?;
         let stringfied_client = serde_json::from_str::<StringfiedEncodedClient>(&client_str)?;
-        Ok(stringfied_client.to_encoded_client()?)
+        stringfied_client.to_encoded_client()
     }
 
     fn regist_from_encoded_client(&self, client: EncodedClient) -> anyhow::Result<()> {

--- a/oxide-auth-iron/Cargo.toml
+++ b/oxide-auth-iron/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxide-auth-iron"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Andreas Molzer <andreas.molzer@gmx.de>"]
 repository = "https://github.com/HeroicKatora/oxide-auth.git"
 
@@ -13,7 +13,7 @@ edition = "2018"
 
 [dependencies]
 iron = "0.6"
-oxide-auth = { version = "0.5.0", path = "../oxide-auth" }
+oxide-auth = { version = "0.6", path = "../oxide-auth" }
 serde_urlencoded = "0.7"
 url = "2"
 

--- a/oxide-auth-iron/Cargo.toml
+++ b/oxide-auth-iron/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxide-auth-iron"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Andreas Molzer <andreas.molzer@gmx.de>"]
 repository = "https://github.com/HeroicKatora/oxide-auth.git"
 

--- a/oxide-auth-iron/src/lib.rs
+++ b/oxide-auth-iron/src/lib.rs
@@ -80,7 +80,7 @@ impl OAuthResponse {
         OAuthResponse(Response::new())
     }
 
-    /// Createa a new OAuthResponse from an existing `iron::Response`
+    /// Create a new OAuthResponse from an existing `iron::Response`
     pub fn from_response(response: Response) -> Self {
         OAuthResponse(response)
     }
@@ -109,10 +109,16 @@ impl OAuthResponse {
     }
 }
 
+impl Default for OAuthResponse {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Requests are handed as mutable reference to the underlying object.
 impl<'a, 'b, 'c: 'b> WebRequest for OAuthRequest<'a, 'b, 'c> {
-    type Response = OAuthResponse;
     type Error = Error;
+    type Response = OAuthResponse;
 
     fn query(&mut self) -> Result<Cow<dyn QueryParameter + 'static>, Self::Error> {
         serde_urlencoded::from_str(self.query_string())
@@ -181,9 +187,9 @@ impl<'a, 'b, 'c: 'b> From<&'a mut Request<'b, 'c>> for OAuthRequest<'a, 'b, 'c> 
     }
 }
 
-impl<'a, 'b, 'c: 'b> Into<&'a mut Request<'b, 'c>> for OAuthRequest<'a, 'b, 'c> {
-    fn into(self) -> &'a mut Request<'b, 'c> {
-        self.0
+impl<'a, 'b, 'c: 'b> From<OAuthRequest<'a, 'b, 'c>> for &'a mut Request<'b, 'c> {
+    fn from(oauth_req: OAuthRequest<'a, 'b, 'c>) -> Self {
+        oauth_req.0
     }
 }
 
@@ -193,15 +199,16 @@ impl From<Response> for OAuthResponse {
     }
 }
 
-impl Into<Response> for OAuthResponse {
-    fn into(self) -> Response {
-        self.0
+impl From<OAuthResponse> for Response {
+    fn from(oauth_resp: OAuthResponse) -> Self {
+        oauth_resp.0
     }
 }
 
 impl<'a, 'b, 'c: 'b> From<SimpleError<OAuthRequest<'a, 'b, 'c>>> for OAuthError {
     fn from(error: SimpleError<OAuthRequest<'a, 'b, 'c>>) -> Self {
         let as_oauth = match error {
+            // if you see an IDE error here its not you or this code, its your IDE.
             SimpleError::Web(Error::BadRequest) => EndpointError::BadRequest,
             SimpleError::OAuth(oauth) => oauth,
         };
@@ -222,8 +229,8 @@ impl From<IronError> for OAuthError {
     }
 }
 
-impl Into<IronError> for OAuthError {
-    fn into(self) -> IronError {
-        self.0
+impl From<OAuthError> for IronError {
+    fn from(oauth_err: OAuthError) -> Self {
+        oauth_err.0
     }
 }

--- a/oxide-auth-poem/Cargo.toml
+++ b/oxide-auth-poem/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxide-auth-poem"
-version = "0.1.0"
+version = "0.2.0"
 repository = "https://github.com/HeroicKatora/oxide-auth.git"
 authors = ["l1npengtul <l1npengtul@protonmail.com>"]
 description = "A OAuth2 server library for Poem featuring a set of configurable and pluggable backends."

--- a/oxide-auth-poem/Cargo.toml
+++ b/oxide-auth-poem/Cargo.toml
@@ -14,6 +14,6 @@ edition = "2021"
 
 [dependencies]
 poem = "1.3"
-oxide-auth = { version = "0.5", path = "../oxide-auth" }
+oxide-auth = { version = "0.6", path = "../oxide-auth" }
 thiserror = "1.0"
 serde_urlencoded = "0.7"

--- a/oxide-auth-rocket/Cargo.toml
+++ b/oxide-auth-rocket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxide-auth-rocket"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Andreas Molzer <andreas.molzer@gmx.de>"]
 repository = "https://github.com/HeroicKatora/oxide-auth.git"
 
@@ -15,7 +15,7 @@ edition = "2018"
 
 [dependencies]
 rocket = "0.4.2"
-oxide-auth = { version = "0.5.0", path = "../oxide-auth" }
+oxide-auth = { version = "0.6", path = "../oxide-auth" }
 serde_urlencoded = "0.7"
 
 [dev-dependencies]

--- a/oxide-auth-rouille/Cargo.toml
+++ b/oxide-auth-rouille/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxide-auth-rouille"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Andreas Molzer <andreas.molzer@gmx.de>"]
 repository = "https://github.com/HeroicKatora/oxide-auth.git"
 edition = "2018"
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 rouille = "3.0"
-oxide-auth = { version = "0.5.0", path = "../oxide-auth" }
+oxide-auth = { version = "0.6", path = "../oxide-auth" }
 serde_urlencoded = "0.7"
 url = "2"
 

--- a/oxide-auth-rouille/src/lib.rs
+++ b/oxide-auth-rouille/src/lib.rs
@@ -6,10 +6,7 @@
 
 use core::ops::Deref;
 use std::borrow::Cow;
-
 use oxide_auth::endpoint::{QueryParameter, WebRequest, WebResponse};
-
-use rouille;
 use url::Url;
 
 // In the spirit of simplicity, this module does not implement any wrapper structures.  In order to

--- a/oxide-auth/Cargo.toml
+++ b/oxide-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxide-auth"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["Andreas Molzer <andreas.molzer@gmx.de>"]
 repository = "https://github.com/HeroicKatora/oxide-auth.git"
 edition = "2018"

--- a/oxide-auth/src/code_grant/access_token.rs
+++ b/oxide-auth/src/code_grant/access_token.rs
@@ -73,7 +73,7 @@ pub trait Request {
     /// RECOMMENDED and need not be supported. The parameters MUST NOT appear in the request URI
     /// itself.
     ///
-    /// Under these considerations, support must be explicitely enabled.
+    /// Under these considerations, support must be explicitly enabled.
     fn allow_credentials_in_body(&self) -> bool {
         false
     }
@@ -143,7 +143,7 @@ enum Credentials<'a> {
 /// parameters for the first step will be extracted from it. It will pose some requests in the form
 /// of [`Output`] which should be satisfied with the next [`Input`] data. This will eventually
 /// produce a [`BearerToken`] or an [`Error`]. Note that the executing environment will need to use
-/// a [`Registrar`], an [`Authorizer`], an optionnal [`Extension`] and an [`Issuer`] to which some
+/// a [`Registrar`], an [`Authorizer`], an optional [`Extension`] and an [`Issuer`] to which some
 /// requests should be forwarded.
 ///
 /// [`Input`]: struct.Input.html
@@ -237,14 +237,14 @@ pub enum Output<'machine> {
     },
     /// The extension (if any) should provide the extensions
     ///
-    /// Fullfilled by `Input::Extended`
+    /// Fulfilled by `Input::Extended`
     Extend {
         /// The grant extensions if any
         extensions: &'machine mut Extensions,
     },
     /// The issue should issue a new access token
     ///
-    /// Fullfilled by `Input::Issued`
+    /// Fulfilled by `Input::Issued`
     Issue {
         /// The grant to be used in the token generation
         grant: &'machine Grant,
@@ -384,7 +384,9 @@ impl AccessToken {
             Some(v) => v,
         };
 
-        if (saved_params.client_id.as_str(), &saved_params.redirect_uri) != (&client_id, &redirect_uri) {
+        if (saved_params.client_id.as_str(), &saved_params.redirect_uri)
+            != (client_id.as_str(), &redirect_uri)
+        {
             return Err(Error::invalid_with(AccessTokenErrorType::InvalidGrant));
         }
 
@@ -534,16 +536,16 @@ pub enum Error {
 }
 
 /// The endpoint should have enough control over its primitives to find
-/// out what has gone wrong, e.g. they may externall supply error
+/// out what has gone wrong, e.g. they may external supply error
 /// information.
 ///
 /// In this case, all previous results returned by the primitives are
 /// included in the return value. Through this mechanism, one can
-/// accomodate async handlers by implementing a sync-based result cache
+/// accommodate async handlers by implementing a sync-based result cache
 /// that is filled with these partial values. In case only parts of the
 /// outstanding futures, invoked during internal calls, are ready the
 /// cache can be refilled through the error eliminating polls to already
-/// sucessful futures.
+/// successful futures.
 ///
 /// Note that `token` is not included in this list, since the handler
 /// can never fail after supplying a token to the backend.
@@ -559,7 +561,7 @@ pub struct PrimitiveError {
     pub extensions: Option<Extensions>,
 }
 
-/// Simple wrapper around AccessTokenError to imbue the type with addtional json functionality. In
+/// Simple wrapper around AccessTokenError to imbue the type with additional json functionality. In
 /// addition this enforces backend specific behaviour for obtaining or handling the access error.
 #[derive(Clone)]
 pub struct ErrorDescription {

--- a/oxide-auth/src/code_grant/authorization.rs
+++ b/oxide-auth/src/code_grant/authorization.rs
@@ -70,7 +70,7 @@ pub trait Endpoint {
     fn extension(&mut self) -> &mut dyn Extension;
 }
 
-/// The result will indicate wether the authorization succeed or not.
+/// The result will indicate whether the authorization succeed or not.
 pub struct Authorization {
     state: AuthorizationState,
     extensions: Option<Extensions>,
@@ -136,7 +136,7 @@ pub enum Output<'machine> {
     },
     /// Ask for extensions if any
     Extend,
-    /// Ask registrar to negociate
+    /// Ask registrar to negotiate
     Negotiate {
         /// The current bound client
         bound_client: &'machine BoundClient<'static>,
@@ -170,7 +170,7 @@ impl Authorization {
     }
 
     /// Go to next state
-    pub fn advance<'req>(&mut self, input: Input<'req>) -> Output<'_> {
+    pub fn advance(&mut self, input: Input) -> Output {
         self.state = match (self.take(), input) {
             (current, Input::None) => current,
             (
@@ -207,7 +207,7 @@ impl Authorization {
             },
             AuthorizationState::Extending { .. } => Output::Extend,
             AuthorizationState::Negotiating { bound_client } => Output::Negotiate {
-                bound_client: &bound_client,
+                bound_client,
                 scope: self.scope.clone(),
             },
             AuthorizationState::Pending {
@@ -216,7 +216,7 @@ impl Authorization {
                 extensions,
             } => Output::Ok {
                 pre_grant: pre_grant.clone(),
-                state: state.clone(),
+                state: state.as_ref().map(Clone::clone), // ??
                 extensions: extensions.clone(),
             },
         }
@@ -302,7 +302,7 @@ impl Authorization {
 
 /// Retrieve allowed scope and redirect url from the registrar.
 ///
-/// Checks the validity of any given input as the registrar instance communicates the registrated
+/// Checks the validity of any given input as the registrar instance communicates the registered
 /// parameters. The registrar can also set or override the requested (default) scope of the client.
 /// This will result in a tuple of negotiated parameters which can be used further to authorize
 /// the client by the owner or, in case of errors, in an action to be taken.
@@ -425,9 +425,9 @@ pub fn authorization_code(handler: &mut dyn Endpoint, request: &dyn Request) -> 
 }
 
 /// Represents a valid, currently pending authorization request not bound to an owner. The frontend
-/// can signal a reponse using this object.
+/// can signal a response using this object.
 // Don't ever implement `Clone` here. It's to make it very
-// hard for the user toaccidentally respond to a request in two conflicting ways. This has
+// hard for the user to accidentally respond to a request in two conflicting ways. This has
 // potential security impact if it could be both denied and authorized.
 pub struct Pending {
     pre_grant: PreGrant,
@@ -506,7 +506,7 @@ pub enum Error {
 
 /// Encapsulates a redirect to a valid redirect_uri with an error response. The implementation
 /// makes it possible to alter the contained error, for example to provide additional optional
-/// information. The error type should not be altered by the frontend but the specificalities
+/// information. The error type should not be altered by the frontend but the specifics
 /// of this should be enforced by the frontend instead.
 #[derive(Clone)]
 pub struct ErrorUrl {
@@ -565,11 +565,10 @@ impl Error {
     }
 }
 
-impl Into<Url> for ErrorUrl {
-    /// Finalize the error url by saving its parameters in the query part of the redirect_uri
-    fn into(self) -> Url {
-        let mut url = self.base_uri;
-        url.query_pairs_mut().extend_pairs(self.error.into_iter());
+impl From<ErrorUrl> for Url {
+    fn from(err_url: ErrorUrl) -> Self {
+        let mut url = err_url.base_uri;
+        url.query_pairs_mut().extend_pairs(err_url.error.into_iter());
         url
     }
 }

--- a/oxide-auth/src/code_grant/mod.rs
+++ b/oxide-auth/src/code_grant/mod.rs
@@ -27,7 +27,7 @@
 //! [`endpoint`]: ../endpoint/index.html
 //! [`Endpoint`]: ../endpoint/trait.Endpoint.html
 
-pub mod accesstoken;
+pub mod access_token;
 pub mod authorization;
 pub mod error;
 pub mod extensions;

--- a/oxide-auth/src/code_grant/refresh.rs
+++ b/oxide-auth/src/code_grant/refresh.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use chrono::{Duration, Utc};
 
 use crate::code_grant::{
-    accesstoken::TokenResponse,
+    access_token::TokenResponse,
     error::{AccessTokenError, AccessTokenErrorType},
 };
 use crate::primitives::grant::Grant;
@@ -301,7 +301,7 @@ impl Refresh {
                 client: &grant.client_id,
                 pass: None,
             },
-            RefreshState::Recovering { token, .. } => Output::RecoverRefresh { token: &token },
+            RefreshState::Recovering { token, .. } => Output::RecoverRefresh { token },
             RefreshState::Issuing { token, grant, .. } => Output::Refresh {
                 token,
                 grant: grant.clone(),
@@ -478,7 +478,7 @@ fn validate(scope: Option<Cow<str>>, grant: Box<Grant>, token: String) -> Result
     let scope = match scope {
         Some(scope) => {
             // ... MUST NOT include any scope not originally granted.
-            if !grant.scope.priviledged_to(&scope) {
+            if !grant.scope.privileged_to(&scope) {
                 // ... or exceeds the scope grant (Section 5.2)
                 return Err(Error::invalid(AccessTokenErrorType::InvalidScope));
             }

--- a/oxide-auth/src/code_grant/resource.rs
+++ b/oxide-auth/src/code_grant/resource.rs
@@ -26,7 +26,7 @@ pub enum ErrorCode {
     /// The request did not have enough authorization data or was otherwise malformed.
     InvalidRequest,
 
-    /// The provided authorization did not grant sufficient priviledges.
+    /// The provided authorization did not grant sufficient privileges.
     InsufficientScope,
 
     /// The token is expired, revoked, malformed or otherwise does not meet expectations.
@@ -122,6 +122,7 @@ enum ResourceState {
 
 /// An input injected by the executor into the state machine.
 #[derive(Clone)]
+#[allow(clippy::large_enum_variant)]
 pub enum Input<'req> {
     /// Provide the queried (bearer) token.
     Recovered(Option<Grant>),
@@ -212,6 +213,12 @@ impl Resource {
 
     fn take(&mut self) -> ResourceState {
         mem::replace(&mut self.state, ResourceState::Err(Error::PrimitiveError))
+    }
+}
+
+impl Default for Resource {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/oxide-auth/src/endpoint/access_token.rs
+++ b/oxide-auth/src/endpoint/access_token.rs
@@ -1,11 +1,17 @@
 use std::str::from_utf8;
 use std::marker::PhantomData;
 
-use crate::code_grant::accesstoken::{
-    access_token, Error as TokenError, Extension, Endpoint as TokenEndpoint, Request as TokenRequest,
+use crate::{
+    code_grant::access_token::{
+        access_token, Error as TokenError, Extension, Endpoint as TokenEndpoint, Request as TokenRequest,
+    },
+    endpoint::NormalizedParameter
 };
 
-use super::*;
+use super::{
+    Authorizer, Cow, Endpoint, InnerTemplate, Issuer, OAuthError, QueryParameter, Registrar, WebRequest,
+    WebResponse,
+};
 
 /// Offers access tokens to authenticated third parties.
 ///
@@ -16,7 +22,7 @@ use super::*;
 ///
 /// Client credentials can be allowed to appear in the request body instead of being
 /// required to be passed as HTTP Basic authorization. This is not recommended and must be
-/// enabled explicitely. See [`allow_credentials_in_body`] for details.
+/// enabled explicitly. See [`allow_credentials_in_body`] for details.
 ///
 /// [`allow_credentials_in_body`]: #method.allow_credentials_in_body
 pub struct AccessTokenFlow<E, R>
@@ -70,7 +76,15 @@ where
     /// Binds the endpoint to a particular type of request that it supports, for many
     /// implementations this is probably single type anyways.
     ///
-    /// ## Panics
+    /// # Errors
+    /// The endpoint needs to give a `Some(_)` value for
+    /// - `registrar`
+    /// - `authorizer`
+    /// - `issuer`
+    /// 
+    /// otherwise this will error.
+    ///
+    /// # Panics
     ///
     /// Indirectly `execute` may panic when this flow is instantiated with an inconsistent
     /// endpoint, for details see the documentation of `Endpoint` and `execute`. For
@@ -104,15 +118,18 @@ where
     /// RECOMMENDED and need not be supported. The parameters MUST NOT appear in the request URI
     /// itself.
     ///
-    /// Thus support is disabled by default and must be explicitely enabled.
+    /// Thus support is disabled by default and must be explicitly enabled.
     pub fn allow_credentials_in_body(&mut self, allow: bool) {
         self.allow_credentials_in_body = allow;
     }
 
     /// Use the checked endpoint to check for authorization for a resource.
     ///
-    /// ## Panics
+    /// # Errors
+    /// If the token returned by the request and handler is invalid, or setting the response body as JSON fails this
+    /// will error.
     ///
+    /// # Panics
     /// When the registrar, authorizer, or issuer returned by the endpoint is suddenly
     /// `None` when previously it was `Some(_)`.
     pub fn execute(&mut self, mut request: R) -> Result<R::Response, E::Error> {
@@ -225,14 +242,15 @@ impl<'a, R: WebRequest + 'a> WrappedRequest<'a, R> {
     fn from_err(err: FailParse<R::Error>) -> Self {
         WrappedRequest {
             request: PhantomData,
-            body: Cow::Owned(Default::default()),
+            body: Cow::Owned(NormalizedParameter::default()),
             authorization: None,
             error: Some(err),
             allow_credentials_in_body: false,
         }
     }
 
-    fn parse_header(header: Cow<str>) -> Result<Authorization, Invalid> {
+    fn parse_header(header: impl AsRef<str>) -> Result<Authorization, Invalid> {
+        let header = header.as_ref();
         let authorization = {
             if !header.starts_with("Basic ") {
                 return Err(Invalid);

--- a/oxide-auth/src/endpoint/mod.rs
+++ b/oxide-auth/src/endpoint/mod.rs
@@ -63,7 +63,7 @@ pub use self::refresh::RefreshFlow;
 pub use self::resource::*;
 pub use self::query::*;
 
-/// Answer from [`OwnerAuthorizer`] to indicate the owners choice.
+/// Answer from `OwnerAuthorizer` to indicate the owners choice.
 pub enum OwnerConsent<Response: WebResponse> {
     /// The owner did not authorize the client.
     Denied,
@@ -302,7 +302,7 @@ pub trait WebRequest {
     type Response: WebResponse<Error = Self::Error>;
 
     /// Retrieve a parsed version of the url query.
-    /// 
+    ///
     /// # Errors
     /// An Err return value indicates a malformed query or an otherwise malformed [`WebRequest`]. Note
     /// that an empty query should result in `Ok(HashMap::new())` instead of an Err.
@@ -315,7 +315,7 @@ pub trait WebRequest {
     fn urlbody(&mut self) -> Result<Cow<dyn QueryParameter + 'static>, Self::Error>;
 
     /// Contents of the authorization header or none if none exists.
-    /// 
+    ///
     /// # Errors
     /// An Err value indicates a malformed header or request.
     fn authheader(&mut self) -> Result<Option<Cow<str>>, Self::Error>;

--- a/oxide-auth/src/endpoint/mod.rs
+++ b/oxide-auth/src/endpoint/mod.rs
@@ -29,7 +29,7 @@
 //! [`Issuer`]: ../../primitives/issuer/trait.Issuer.html
 //! [`Registrar`]: ../../primitives/registrar/trait.Registrar.html
 mod authorization;
-mod accesstoken;
+mod access_token;
 mod error;
 mod refresh;
 mod resource;
@@ -53,17 +53,17 @@ use url::Url;
 
 // Re-export the extension traits under prefixed names.
 pub use crate::code_grant::authorization::Extension as AuthorizationExtension;
-pub use crate::code_grant::accesstoken::Extension as AccessTokenExtension;
+pub use crate::code_grant::access_token::Extension as AccessTokenExtension;
 
 pub use crate::primitives::registrar::PreGrant;
 pub use self::authorization::*;
-pub use self::accesstoken::*;
+pub use self::access_token::*;
 pub use self::error::OAuthError;
 pub use self::refresh::RefreshFlow;
 pub use self::resource::*;
 pub use self::query::*;
 
-/// Answer from OwnerAuthorizer to indicate the owners choice.
+/// Answer from [`OwnerAuthorizer`] to indicate the owners choice.
 pub enum OwnerConsent<Response: WebResponse> {
     /// The owner did not authorize the client.
     Denied,
@@ -124,6 +124,7 @@ enum InnerTemplate<'a> {
         /// The underlying cause for denying access.
         ///
         /// The http authorization header is to be set according to this field.
+        #[allow(dead_code)]
         error: Option<ResourceError>,
 
         /// Information on an access token error.
@@ -183,6 +184,7 @@ impl<'flow> Solicitation<'flow> {
     /// Clone the solicitation into an owned structure.
     ///
     /// This mainly helps with sending it across threads.
+    #[must_use]
     pub fn into_owned(self) -> Solicitation<'static> {
         Solicitation {
             grant: Cow::Owned(self.grant.into_owned()),
@@ -195,6 +197,7 @@ impl<'flow> Solicitation<'flow> {
     /// The information in the `PreGrant` is the authoritative information on the client and scopes
     /// associated with the request. It has already been validated against those settings and
     /// restrictions that were applied when registering the client.
+    #[must_use]
     pub fn pre_grant(&self) -> &PreGrant {
         self.grant.as_ref()
     }
@@ -203,17 +206,20 @@ impl<'flow> Solicitation<'flow> {
     ///
     /// This will need to be provided to the response back to the client so it must be preserved
     /// across a redirect or a consent screen presented by the user agent.
+    #[must_use]
     pub fn state(&self) -> Option<&str> {
-        match self.state {
-            None => None,
-            Some(ref state) => Some(&state),
-        }
+        // match self.state {
+        //     None => None,
+        //     Some(ref state) => Some(state),
+        // }
+        self.state.as_ref().map(AsRef::as_ref)
     }
 
     /// Create a new solicitation request from a pre grant.
     ///
     /// You usually wouldn't need to call this manually as it is called by the endpoint's flow and
     /// then handed with all available information to the solicitor.
+    #[must_use]
     pub fn new(grant: &'flow PreGrant) -> Self {
         Solicitation {
             grant: Cow::Borrowed(grant),
@@ -222,6 +228,7 @@ impl<'flow> Solicitation<'flow> {
     }
 
     /// Add a client state to the solicitation.
+    #[must_use]
     pub fn with_state(self, state: &'flow str) -> Self {
         Solicitation {
             state: Some(Cow::Borrowed(state)),
@@ -295,25 +302,32 @@ pub trait WebRequest {
     type Response: WebResponse<Error = Self::Error>;
 
     /// Retrieve a parsed version of the url query.
-    ///
-    /// An Err return value indicates a malformed query or an otherwise malformed WebRequest. Note
+    /// 
+    /// # Errors
+    /// An Err return value indicates a malformed query or an otherwise malformed [`WebRequest`]. Note
     /// that an empty query should result in `Ok(HashMap::new())` instead of an Err.
     fn query(&mut self) -> Result<Cow<dyn QueryParameter + 'static>, Self::Error>;
 
     /// Retrieve the parsed `application/x-form-urlencoded` body of the request.
     ///
+    /// # Errors
     /// An Err value / indicates a malformed body or a different Content-Type.
     fn urlbody(&mut self) -> Result<Cow<dyn QueryParameter + 'static>, Self::Error>;
 
-    /// Contents of the authorization header or none if none exists. An Err value indicates a
-    /// malformed header or request.
+    /// Contents of the authorization header or none if none exists.
+    /// 
+    /// # Errors
+    /// An Err value indicates a malformed header or request.
     fn authheader(&mut self) -> Result<Option<Cow<str>>, Self::Error>;
 }
 
-/// Response representation into which the Request is transformed by the code_grant types.
+/// Response representation into which the Request is transformed by the `code_grant` types.
 ///
 /// At most one of the methods `body_text`, `body_json` will be called. Some flows will
 /// however not call any of those methods.
+/// # Errors
+/// If one of these fields failed to set, the method will error
+#[allow(clippy::missing_errors_doc)]
 pub trait WebResponse {
     /// The error generated when trying to construct an unhandled or invalid response.
     type Error;
@@ -333,7 +347,7 @@ pub trait WebResponse {
     /// A pure text response with no special media type set.
     fn body_text(&mut self, text: &str) -> Result<(), Self::Error>;
 
-    /// Json repsonse data, with media type `aplication/json.
+    /// Json repsonse data, with media type `aplication/json`.
     fn body_json(&mut self, data: &str) -> Result<(), Self::Error>;
 }
 

--- a/oxide-auth/src/endpoint/query.rs
+++ b/oxide-auth/src/endpoint/query.rs
@@ -17,7 +17,7 @@ use serde::Deserializer;
 /// * `HashMap<String, String>`
 /// * `HashMap<String, Vec<String>>`
 /// * `HashMap<Cow<'static, str>, Cow<'static, str>>`
-/// 
+///
 /// # Safety
 /// You should generally not have to implement this trait yourself, and if you do there are
 /// additional requirements on your implementation to guarantee standard conformance. Therefore the
@@ -42,7 +42,7 @@ pub unsafe trait QueryParameter {
 /// in the memory associated with the request, it needs to be allocated to outlive the borrow on
 /// the request.  This allocation may as well perform the minimization/normalization into a
 /// representation actually consumed by the backend. This normal form thus encapsulates the
-/// associated `clone-into-normal form` by various possible constructors from references [WIP].
+/// associated `clone-into-normal form` by various possible constructors from references \[WIP\].
 ///
 /// This gives rise to a custom `Cow<QueryParameter>` instance by requiring that normalization into
 /// memory with unrelated lifetime is always possible.
@@ -68,7 +68,8 @@ unsafe impl QueryParameter for NormalizedParameter {
 
 impl NormalizedParameter {
     /// Create an empty map.
-    #[must_use] pub fn new() -> Self {
+    #[must_use]
+    pub fn new() -> Self {
         NormalizedParameter::default()
     }
 
@@ -167,7 +168,7 @@ impl ToOwned for dyn QueryParameter + Send {
 ///
 /// If this were done with slices, that would require choosing a particular
 /// value type of the underlying slice e.g. `[String]`.
-/// 
+///
 /// # Safety
 /// Generally, you do not need to implement this yourself. However, there are constraints for
 /// correct implementations if you do, thus this trait is marked `unsafe`.

--- a/oxide-auth/src/endpoint/tests/mod.rs
+++ b/oxide-auth/src/endpoint/tests/mod.rs
@@ -74,8 +74,8 @@ enum CraftedError {
 }
 
 impl WebRequest for CraftedRequest {
-    type Response = CraftedResponse;
     type Error = CraftedError;
+    type Response = CraftedResponse;
 
     fn query(&mut self) -> Result<Cow<dyn QueryParameter + 'static>, Self::Error> {
         self.query

--- a/oxide-auth/src/endpoint/tests/pkce.rs
+++ b/oxide-auth/src/endpoint/tests/pkce.rs
@@ -3,7 +3,7 @@ use crate::primitives::issuer::TokenMap;
 use crate::primitives::generator::RandomGenerator;
 use crate::primitives::registrar::{Client, ClientMap, RegisteredUrl};
 
-use crate::code_grant::accesstoken::TokenResponse;
+use crate::code_grant::access_token::TokenResponse;
 use crate::endpoint::{AuthorizationFlow, AccessTokenFlow, Endpoint};
 use crate::frontends::simple::extensions::{AddonList, Extended, Pkce};
 use crate::frontends::simple::endpoint::{Generic, Error, Vacant};
@@ -38,9 +38,9 @@ impl PkceSetup {
         let issuer = TokenMap::new(RandomGenerator::new(16));
 
         PkceSetup {
-            registrar: registrar,
-            authorizer: authorizer,
-            issuer: issuer,
+            registrar,
+            authorizer,
+            issuer,
             auth_token: token,
             // The following are from https://tools.ietf.org/html/rfc7636#page-18
             sha256_challenge: "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM".to_string(),

--- a/oxide-auth/src/endpoint/tests/refresh.rs
+++ b/oxide-auth/src/endpoint/tests/refresh.rs
@@ -11,7 +11,7 @@ use serde_json;
 
 use super::{Body, CraftedRequest, CraftedResponse, Status, ToSingleValueQuery};
 use super::defaults::*;
-use crate::code_grant::accesstoken::TokenResponse;
+use crate::code_grant::access_token::TokenResponse;
 use crate::frontends::simple::endpoint::{refresh_flow, resource_flow};
 
 struct RefreshTokenSetup {
@@ -89,7 +89,7 @@ impl RefreshTokenSetup {
         assert!(issued.refreshable());
         let refresh_token = issued.refresh.clone().unwrap();
 
-        let basic_authorization = "DO_NOT_USE".into();
+        let basic_authorization = "DO_NOT_USE".to_string();
 
         RefreshTokenSetup {
             registrar,

--- a/oxide-auth/src/frontends/mod.rs
+++ b/oxide-auth/src/frontends/mod.rs
@@ -18,8 +18,8 @@
 //!
 //! ## Guide to implementing a custom front-end
 //!
-//! All front-end implementations should start with two closely related traits: [`WebRequest`] and
-//! [`WebResponse`].  These central interfaces are used to interact with the libraries supported
+//! All front-end implementations should start with two closely related traits: `WebRequest` and
+//! `WebResponse`.  These central interfaces are used to interact with the libraries supported
 //! token flows (currently only authorization code grant).
 //!
 //! Lets step through those implementations one by one.  As an example request type, let's pretend

--- a/oxide-auth/src/frontends/simple/endpoint.rs
+++ b/oxide-auth/src/frontends/simple/endpoint.rs
@@ -36,7 +36,7 @@ pub enum Error<W: WebRequest> {
 
 /// A rather basic [`Endpoint`] implementation.
 ///
-/// Substitue all parts that are not provided with the marker struct [`Vacant`]. This will at least
+/// Substitute all parts that are not provided with the marker struct [`Vacant`]. This will at least
 /// ensure that no security properties are violated. Some flows may be unavailable when some
 /// primitives are missing. See [`AuthorizationFlow`], [`AccessTokenFlow`], [`ResourceFlow`] for
 /// more details.
@@ -60,7 +60,7 @@ pub enum Error<W: WebRequest> {
 /// ## Example
 ///
 /// Here is an example where a `Generic` is used to set up an endpoint that is filled with the
-/// minimal members to be useable for an [`AccessTokenFlow`].
+/// minimal members to be usable for an [`AccessTokenFlow`].
 ///
 /// ```
 /// # extern crate oxide_auth;
@@ -96,16 +96,16 @@ pub enum Error<W: WebRequest> {
 /// [`ResourceFlow`]: ../../../endpoint/struct.ResourceFlow.html
 /// [`ResourceFlow`]: ../../../endpoint/trait.Scopes.html
 pub struct Generic<R, A, I, S = Vacant, C = Vacant, L = Vacant> {
-    /// The registrar implementation, or `Vacant` if it is not necesary.
+    /// The registrar implementation, or `Vacant` if it is not necessary.
     pub registrar: R,
 
-    /// The authorizer implementation, or `Vacant` if it is not necesary.
+    /// The authorizer implementation, or `Vacant` if it is not necessary.
     pub authorizer: A,
 
-    /// The issuer implementation, or `Vacant` if it is not necesary.
+    /// The issuer implementation, or `Vacant` if it is not necessary.
     pub issuer: I,
 
-    /// A solicitor implementation fit for the request types, or `Vacant` if it is not necesary.
+    /// A solicitor implementation fit for the request types, or `Vacant` if it is not necessary.
     pub solicitor: S,
 
     /// Determine scopes for the request types, or `Vacant` if this does not protect resources.
@@ -151,7 +151,7 @@ impl<E, Error> ErrorInto<E, Error> {
 ///
 /// ## Scopes
 ///
-/// Returns an empty list of scopes, effictively denying all requests since at least one scope
+/// Returns an empty list of scopes, effectively denying all requests since at least one scope
 /// needs to be fulfilled by token to gain access.
 ///
 /// See [OwnerSolicitor](#OwnerSolicitor) for discussion on why this differs from the other
@@ -487,7 +487,7 @@ impl<W: WebRequest> Error<W> {
     /// Convert into a single error type.
     ///
     /// Note that the additional information whether the error occurred in the web components or
-    /// during the flow needs to be implicitely contained in the types. Otherwise, this information
+    /// during the flow needs to be implicitly contained in the types. Otherwise, this information
     /// is lost and you should use or provide a `From<Error<W>>` implementation instead. This
     /// method is still useful for frontends providing a standard error type that interacts with
     /// their web server library.

--- a/oxide-auth/src/frontends/simple/extensions/extended.rs
+++ b/oxide-auth/src/frontends/simple/extensions/extended.rs
@@ -26,7 +26,7 @@ impl<Inner> Extended<Inner, AddonList> {
 }
 
 impl<Inner, E> Extended<Inner, E> {
-    /// Wrap an inner endpoint with a preconstructed extension instance.
+    /// Wrap an inner endpoint with a pre-constructed extension instance.
     pub fn extend_with(inner: Inner, extension: E) -> Self {
         Extended {
             inner,

--- a/oxide-auth/src/frontends/simple/extensions/list.rs
+++ b/oxide-auth/src/frontends/simple/extensions/list.rs
@@ -2,7 +2,7 @@ use std::fmt;
 use std::sync::Arc;
 
 use super::{AuthorizationAddon, AccessTokenAddon, AddonResult};
-use crate::code_grant::accesstoken::{Extension as AccessTokenExtension, Request};
+use crate::code_grant::access_token::{Extension as AccessTokenExtension, Request};
 use crate::code_grant::authorization::{Extension as AuthorizationExtension, Request as AuthRequest};
 use crate::endpoint::Extension;
 use crate::primitives::grant::{Extensions, GrantExtension};

--- a/oxide-auth/src/frontends/simple/extensions/mod.rs
+++ b/oxide-auth/src/frontends/simple/extensions/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! Note that extensions will probably return in `v0.4` but not its preview versions.
 pub use crate::code_grant::authorization::Request as AuthorizationRequest;
-pub use crate::code_grant::accesstoken::Request as AccessTokenRequest;
+pub use crate::code_grant::access_token::Request as AccessTokenRequest;
 
 mod extended;
 mod pkce;

--- a/oxide-auth/src/frontends/simple/extensions/pkce.rs
+++ b/oxide-auth/src/frontends/simple/extensions/pkce.rs
@@ -9,9 +9,9 @@ impl AuthorizationAddon for Pkce {
         let challenge = request.extension("code_challenge");
 
         let encoded = match self.challenge(method, challenge) {
-            Err(()) => return AddonResult::Err,
             Ok(None) => return AddonResult::Ok,
             Ok(Some(encoded)) => encoded,
+            Err(_) => return AddonResult::Err,
         };
 
         AddonResult::Data(encoded)

--- a/oxide-auth/src/frontends/simple/mod.rs
+++ b/oxide-auth/src/frontends/simple/mod.rs
@@ -1,4 +1,4 @@
-//! A baseline implemention of [`Endpoint`] and [`WebRequest`].
+//! A baseline implementation of [`Endpoint`] and [`WebRequest`].
 //!
 //! Contains primitive extension implementations as well as straightforward request formats
 //! suitable for HTTP-less OAuth applications. This is useful for testing as well as token

--- a/oxide-auth/src/frontends/simple/request.rs
+++ b/oxide-auth/src/frontends/simple/request.rs
@@ -171,7 +171,7 @@ impl WebResponse for Response {
         Ok(())
     }
 
-    /// Json repsonse data, with media type `aplication/json.
+    /// Json response data, with media type `application/json.
     fn body_json(&mut self, data: &str) -> Result<(), Self::Error> {
         self.body = Some(Body::Json(data.to_owned()));
         Ok(())
@@ -243,7 +243,7 @@ where
         self.0.body_text(text).map_err(&mut self.1)
     }
 
-    /// Json repsonse data, with media type `aplication/json.
+    /// Json response data, with media type `application/json`.
     fn body_json(&mut self, data: &str) -> Result<(), Self::Error> {
         self.0.body_json(data).map_err(&mut self.1)
     }

--- a/oxide-auth/src/lib.rs
+++ b/oxide-auth/src/lib.rs
@@ -64,8 +64,12 @@
 //! [`OwnerSolicitor`]: endpoint/trait.OwnerSolicitor.html
 //! [`Scopes`]: endpoint/trait.Scopes.html
 #![warn(missing_docs)]
+#![warn(clippy::all)]
+#![allow(clippy::module_name_repetitions)]
+#![allow(clippy::result_unit_err)]
 
 pub mod code_grant;
 pub mod endpoint;
 pub mod frontends;
 pub mod primitives;
+mod util;

--- a/oxide-auth/src/primitives/authorizer.rs
+++ b/oxide-auth/src/primitives/authorizer.rs
@@ -104,7 +104,7 @@ impl<I: TagGrant> Authorizer for AuthMap<I> {
         Ok(token)
     }
 
-    fn extract<'a>(&mut self, grant: &'a str) -> Result<Option<Grant>, ()> {
+    fn extract(&mut self, grant: &str) -> Result<Option<Grant>, ()> {
         Ok(self.tokens.remove(grant))
     }
 }

--- a/oxide-auth/src/primitives/generator.rs
+++ b/oxide-auth/src/primitives/generator.rs
@@ -161,7 +161,7 @@ impl Assertion {
         TaggedAssertion(self, tag)
     }
 
-    fn extract<'a>(&self, token: &'a str) -> Result<(Grant, String), ()> {
+    fn extract(&self, token: &str) -> Result<(Grant, String), ()> {
         let decoded = decode(token).map_err(|_| ())?;
         let assertion: AssertGrant = rmp_serde::from_slice(&decoded).map_err(|_| ())?;
 
@@ -214,7 +214,7 @@ impl<'a> TaggedAssertion<'a> {
     ///
     /// Result in an Err if either the signature is invalid or if the tag does not match the
     /// expected usage tag given to this assertion.
-    pub fn extract<'b>(&self, token: &'b str) -> Result<Grant, ()> {
+    pub fn extract(&self, token: &str) -> Result<Grant, ()> {
         self.0
             .extract(token)
             .and_then(|(token, tag)| if tag == self.1 { Ok(token) } else { Err(()) })
@@ -304,7 +304,7 @@ mod url_serde {
     use serde::de::{Deserialize, Deserializer, Error};
 
     pub fn serialize<S: Serializer>(url: &Url, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_str(&url.to_string())
+        serializer.serialize_str(url.as_ref())
     }
 
     pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Url, D::Error> {

--- a/oxide-auth/src/primitives/grant.rs
+++ b/oxide-auth/src/primitives/grant.rs
@@ -1,4 +1,4 @@
-//! Encapsulates various shared mechanisms for handlings different grants.
+//! Encapsulates various shared mechanisms for handling different grants.
 use super::{Url, Time};
 use super::scope::Scope;
 
@@ -29,7 +29,7 @@ pub enum Value {
     /// An extension that the token owner is allowed to read and interpret.
     Public(Option<String>),
 
-    /// Identifies an extenion whose content and/or existance MUST be kept secret.
+    /// Identifies an extension whose content and/or existence MUST be kept secret.
     Private(Option<String>),
     // Content which is not saved on the server but initialized/interpreted from other sources.
     // foreign_content: String,
@@ -93,7 +93,7 @@ impl Value {
     /// but consists only of the key, and `Some(_)` otherwise.
     pub fn public_value(&self) -> Result<Option<&str>, ()> {
         match self {
-            Value::Public(Some(content)) => Ok(Some(&content)),
+            Value::Public(Some(content)) => Ok(Some(content)),
             Value::Public(None) => Ok(None),
             _ => Err(()),
         }
@@ -116,7 +116,7 @@ impl Value {
     /// but consists only of the key, and `Some(_)` otherwise.
     pub fn private_value(&self) -> Result<Option<&str>, ()> {
         match self {
-            Value::Private(Some(content)) => Ok(Some(&content)),
+            Value::Private(Some(content)) => Ok(Some(content)),
             Value::Private(None) => Ok(None),
             _ => Err(()),
         }
@@ -153,7 +153,7 @@ impl Extensions {
 
     /// Retrieve the stored data of an instance.
     ///
-    /// This removes the data from the store to avoid possible mixups and to allow a copyless
+    /// This removes the data from the store to avoid possible mix-ups and to allow a copyless
     /// retrieval of bigger data strings.
     pub fn remove(&mut self, extension: &dyn GrantExtension) -> Option<Value> {
         self.extensions.remove(extension.identifier())

--- a/oxide-auth/src/primitives/mod.rs
+++ b/oxide-auth/src/primitives/mod.rs
@@ -1,4 +1,4 @@
-//! A collection of primites useful for more than one authorization method.
+//! A collection of primitives useful for more than one authorization method.
 //!
 //! A primitive is the smallest independent unit of policy used in OAuth related endpoints. For
 //! example, an `authorizer` generates and verifies Authorization Codes.  There only is, as you

--- a/oxide-auth/src/primitives/registrar.rs
+++ b/oxide-auth/src/primitives/registrar.rs
@@ -19,7 +19,7 @@ use rand::{RngCore, thread_rng};
 use serde::{Deserialize, Serialize};
 use url::{Url, ParseError as ParseUrlError};
 
-/// Registrars provie a way to interact with clients.
+/// Registrars provide a way to interact with clients.
 ///
 /// Most importantly, they determine defaulted parameters for a request as well as the validity
 /// of provided parameters. In general, implementations of this trait will probably offer an
@@ -101,7 +101,7 @@ impl<'de> Deserialize<'de> for ExactUrl {
         D: serde::Deserializer<'de>,
     {
         let string: &str = Deserialize::deserialize(deserializer)?;
-        core::str::FromStr::from_str(&string).map_err(serde::de::Error::custom)
+        core::str::FromStr::from_str(string).map_err(serde::de::Error::custom)
     }
 }
 
@@ -207,7 +207,7 @@ pub struct PreGrant {
 /// Handled responses from a registrar.
 #[derive(Clone, Debug)]
 pub enum RegistrarError {
-    /// One of several different causes that should be indistiguishable.
+    /// One of several different causes that should be indistinguishable.
     ///
     /// * Indicates an entirely unknown client.
     /// * The client is not authorized.
@@ -215,7 +215,7 @@ pub enum RegistrarError {
     ///   exact match on the url, to prevent injection of bad query parameters for example but not
     ///   strictly required.
     ///
-    /// These should be indistiguishable to avoid security problems.
+    /// These should be indistinguishable to avoid security problems.
     Unspecified,
 
     /// Something went wrong with this primitive that has no security reason.
@@ -600,9 +600,11 @@ pub struct Argon2 {
 
 impl PasswordPolicy for Argon2 {
     fn store(&self, client_id: &str, passphrase: &[u8]) -> Vec<u8> {
-        let mut config = Config::default();
-        config.ad = client_id.as_bytes();
-        config.secret = &[];
+        let config = Config {
+            ad: client_id.as_bytes(),
+            secret: &[],
+            ..Default::default()
+        };
 
         let mut salt = vec![0; 32];
         thread_rng()
@@ -649,7 +651,7 @@ impl ClientMap {
     }
 
     // This is not an instance method because it needs to borrow the box but register needs &mut
-    fn current_policy<'a>(policy: &'a Option<Box<dyn PasswordPolicy>>) -> &'a dyn PasswordPolicy {
+    fn current_policy(policy: &Option<Box<dyn PasswordPolicy>>) -> &dyn PasswordPolicy {
         policy
             .as_ref()
             .map(|boxed| &**boxed)
@@ -862,8 +864,7 @@ mod tests {
                 .expect("Authorization of public client has changed");
             registrar
                 .check(public_id, Some(b""))
-                .err()
-                .expect("Authorization with password succeeded");
+                .expect_err("Authorization with password succeeded");
         }
 
         let private_client = Client::confidential(
@@ -881,8 +882,7 @@ mod tests {
                 .expect("Authorization with right password did not succeed");
             registrar
                 .check(private_id, Some(b"Not the private passphrase"))
-                .err()
-                .expect("Authorization succeed with wrong password");
+                .expect_err("Authorization succeed with wrong password");
         }
     }
 

--- a/oxide-auth/src/primitives/registrar.rs
+++ b/oxide-auth/src/primitives/registrar.rs
@@ -127,7 +127,7 @@ impl<'de> Deserialize<'de> for ExactUrl {
 ///
 /// # Note
 ///
-/// Local host ips (e.g. 127.0.0.1, [::1]) are treated as non-localhosts, so their ports are
+/// Local host ips (e.g. 127.0.0.1, \[::1\]) are treated as non-localhosts, so their ports are
 /// considered.
 ///
 /// [`ExactUrl`]: ExactUrl

--- a/oxide-auth/src/primitives/scope.rs
+++ b/oxide-auth/src/primitives/scope.rs
@@ -72,20 +72,20 @@ impl Scope {
     fn invalid_scope_char(ch: char) -> bool {
         match ch {
             '\x21' => false,
-            ch if ch >= '\x23' && ch <= '\x5b' => false,
-            ch if ch >= '\x5d' && ch <= '\x7e' => false,
-            ' ' => false, // Space seperator is a valid char
+            ch if ('\x23'..='\x5b').contains(&ch) => false,
+            ch if ('\x5d'..='\x7e').contains(&ch) => false,
+            ' ' => false, // Space separator is a valid char
             _ => true,
         }
     }
 
     /// Determines if this scope has enough privileges to access some resource requiring the scope
     /// on the right side. This operation is equivalent to comparison via `>=`.
-    pub fn priviledged_to(&self, rhs: &Scope) -> bool {
+    pub fn privileged_to(&self, rhs: &Scope) -> bool {
         rhs <= self
     }
 
-    /// Determines if a resouce protected by this scope should allow access to a token with the
+    /// Determines if a resource protected by this scope should allow access to a token with the
     /// grant on the right side. This operation is equivalent to comparison via `<=`.
     pub fn allow_access(&self, rhs: &Scope) -> bool {
         self <= rhs
@@ -202,16 +202,16 @@ mod tests {
 
         assert_eq!(scope_base.partial_cmp(&scope_base), Some(cmp::Ordering::Equal));
 
-        assert!(scope_base.priviledged_to(&scope_less));
-        assert!(scope_base.priviledged_to(&scope_base));
+        assert!(scope_base.privileged_to(&scope_less));
+        assert!(scope_base.privileged_to(&scope_base));
         assert!(scope_less.allow_access(&scope_base));
         assert!(scope_base.allow_access(&scope_base));
 
-        assert!(!scope_less.priviledged_to(&scope_base));
+        assert!(!scope_less.privileged_to(&scope_base));
         assert!(!scope_base.allow_access(&scope_less));
 
-        assert!(!scope_less.priviledged_to(&scope_uncmp));
-        assert!(!scope_base.priviledged_to(&scope_uncmp));
+        assert!(!scope_less.privileged_to(&scope_uncmp));
+        assert!(!scope_base.privileged_to(&scope_uncmp));
         assert!(!scope_uncmp.allow_access(&scope_less));
         assert!(!scope_uncmp.allow_access(&scope_base));
     }

--- a/oxide-auth/src/util.rs
+++ b/oxide-auth/src/util.rs
@@ -1,0 +1,9 @@
+use std::borrow::Cow;
+
+// avoids allocation on `Cow::Owned`.
+pub fn avoid_alloc_cow_str_to_string(cow: Cow<str>) -> String {
+    match cow {
+        Cow::Borrowed(b) => b.to_string(),
+        Cow::Owned(o) => o,
+    }
+}


### PR DESCRIPTION
This PR fixes ~40+ clippy warnings and documentation typos in the main crate, along with many others in the subsequent crates for those using `oxide-auth`.

This also bumps oxide-auth and all its related crates by 1 minor version to comply with SemVer(lots of `Into -> From`s, possible breaking API changes) and to update the oxide-auth to 0.6

 - [x] I have read the [contribution guidelines][Contributing]

I license past and future contributions under the dual MIT/Apache-2.0 license, allowing licensees to chose either at their option.
