### PR TITLE
make "Bearer" handling 'case insensitive'

### DIFF
--- a/oxide-auth/src/code_grant/resource.rs
+++ b/oxide-auth/src/code_grant/resource.rs
@@ -266,7 +266,10 @@ fn validate(request: &'_ dyn Request) -> Result<ResourceState> {
         }
     };
 
-    if !client_token.starts_with(BEARER_START) {
+    if !client_token
+        .to_uppercase()
+        .starts_with(&BEARER_START.to_uppercase())
+    {
         return Err(Error::InvalidRequest {
             authenticate: Authenticate::empty(),
         });

--- a/oxide-auth/src/endpoint/tests/resource.rs
+++ b/oxide-auth/src/endpoint/tests/resource.rs
@@ -95,6 +95,26 @@ fn resource_success() {
 }
 
 #[test]
+fn resource_casing_success() {
+    let mut setup = ResourceSetup::new();
+    let success = CraftedRequest {
+        query: None,
+        urlbody: None,
+        auth: Some("bearer ".to_string() + &setup.authtoken),
+    };
+
+    setup.test_access_success(success);
+
+    let success = CraftedRequest {
+        query: None,
+        urlbody: None,
+        auth: Some("bEArEr ".to_string() + &setup.authtoken),
+    };
+
+    setup.test_access_success(success);
+}
+
+#[test]
 fn resource_no_authorization() {
     // Does not have any authorization
     let no_authorization = CraftedRequest {


### PR DESCRIPTION
https://next-auth.js.org/ seems to use a lower case `bearer` which didn't work with oxide-auth.

This changes/fixes/improves &#8230;

 - [x] I have read the [contribution guidelines][Contributing]
 - [x] This change has tests (remove for doc only)
 - [ ] This change has documentation
 - [ ] Corresponds to issue (number)

I license past and future contributions under the dual MIT/Apache-2.0 license, allowing licensees to chose either at their option.

[Contributing]: CONTRIBUTING.md
