### PR TITLE
Release oxide auth 0.5.2

### DIFF
--- a/oxide-auth/Cargo.toml
+++ b/oxide-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxide-auth"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Andreas Molzer <andreas.molzer@gmx.de>"]
 repository = "https://github.com/HeroicKatora/oxide-auth.git"
 edition = "2018"
@@ -17,16 +17,16 @@ autoexamples = false
 [dependencies]
 base64 = "0.13"
 chrono = "0.4.2"
-hmac = "0.11.0"
+hmac = "0.12.0"
 once_cell = "1.3.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0"
 serde_json = "1.0"
-sha2 = "0.9.1"
+sha2 = "0.10.1"
 subtle = "2.4.1"
 rand = "0.8"
-rust-argon2 = "0.8.3"
-rmp-serde = "0.15"
+rust-argon2 = "1.0"
+rmp-serde = "1.1"
 url = { version = "2.2.2", features = ["serde"] }
 
 [dev-dependencies]

--- a/oxide-auth/Changes.md
+++ b/oxide-auth/Changes.md
@@ -2,6 +2,20 @@ Versions follow SemVer, of course. Major milestone versions are named in
 alphabetic order and will be accompanied by notes in [the migration
 notes](Migration.md)
 
+# v0.5.2 (2022-Jul-10)
+
+Maintenance release:
+- Updates a few internal dependencies: `hmac`, `sha2`, `rust-argon2`,
+  `rmp-serde`. Of these, both `rust-argon2` and `rmp-serde` have reached stable
+  version `1`. Future version may expose their types for more in-depth
+  interactions.
+
+Bug fixes:
+- Parsing `Authorization` header now matches the type with a case insensitive
+  comparison. This affects usage of `Bearer` authentication in the resource
+  flow and handling of client authentication in the refresh and access token
+  flows.
+
 # v0.5.1
 
 Maintenance release

--- a/oxide-auth/src/endpoint/mod.rs
+++ b/oxide-auth/src/endpoint/mod.rs
@@ -682,3 +682,12 @@ impl<'a> From<InnerTemplate<'a>> for Template<'a> {
         Template { inner }
     }
 }
+
+fn is_authorization_method<'h>(header: &'h str, method: &'static str) -> Option<&'h str> {
+    let header_method = header.get(..method.len())?;
+    if header_method.eq_ignore_ascii_case(method) {
+        Some(&header[method.len()..])
+    } else {
+        None
+    }
+}

--- a/oxide-auth/src/endpoint/tests/access_token.rs
+++ b/oxide-auth/src/endpoint/tests/access_token.rs
@@ -181,6 +181,27 @@ fn access_valid_private() {
     setup.test_success(valid_public);
 }
 
+#[test]
+fn regression_case_insensitive_basic() {
+    let mut setup = AccessTokenSetup::private_client();
+
+    let valid_public = CraftedRequest {
+        query: None,
+        urlbody: Some(
+            vec![
+                ("grant_type", "authorization_code"),
+                ("code", &setup.authtoken),
+                ("redirect_uri", EXAMPLE_REDIRECT_URI),
+            ]
+            .iter()
+            .to_single_value_query(),
+        ),
+        auth: Some("basic ".to_string() + &setup.basic_authorization),
+    };
+
+    setup.test_success(valid_public);
+}
+
 // When creating a client from a preparsed url expect all equivalent urls to also be valid
 // parameters for the redirect_uri. Partly because `Url` already does some normalization during
 // parsing. The RFC recommends string-based comparison when the 'client registration included the

--- a/oxide-auth/src/endpoint/tests/refresh.rs
+++ b/oxide-auth/src/endpoint/tests/refresh.rs
@@ -341,6 +341,27 @@ fn invalid_request() {
 }
 
 #[test]
+fn regression_case_insensitive_basic() {
+    let mut setup = RefreshTokenSetup::private_client();
+
+    setup.basic_authorization.replace_range(..6, "basic ");
+    let case_changed_authorization = CraftedRequest {
+        query: None,
+        urlbody: Some(
+            vec![
+                ("grant_type", "refresh_token"),
+                ("refresh_token", &setup.refresh_token),
+            ]
+            .iter()
+            .to_single_value_query(),
+        ),
+        auth: Some(setup.basic_authorization.clone()),
+    };
+
+    setup.assert_success(case_changed_authorization);
+}
+
+#[test]
 fn public_invalid_token() {
     const WRONG_REFRESH_TOKEN: &str = "not_the_issued_token";
     let mut setup = RefreshTokenSetup::public_client();

--- a/oxide-auth/src/primitives/generator.rs
+++ b/oxide-auth/src/primitives/generator.rs
@@ -19,7 +19,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use base64::{encode, decode};
-use hmac::{crypto_mac::Output, Mac, Hmac, NewMac};
+use hmac::{digest::CtOutput, Mac, Hmac};
 use rand::{rngs::OsRng, RngCore, thread_rng};
 use serde::{Deserialize, Serialize};
 use rmp_serde;
@@ -167,7 +167,7 @@ impl Assertion {
 
         let mut hasher = self.hasher.clone();
         hasher.update(&assertion.0);
-        hasher.verify(assertion.1.as_slice()).map_err(|_| ())?;
+        hasher.verify_slice(assertion.1.as_slice()).map_err(|_| ())?;
 
         let (_, serde_grant, tag): (u64, SerdeAssertionGrant, String) =
             rmp_serde::from_slice(&assertion.0).map_err(|_| ())?;
@@ -175,7 +175,7 @@ impl Assertion {
         Ok((serde_grant.grant(), tag))
     }
 
-    fn signature(&self, data: &[u8]) -> Output<hmac::Hmac<sha2::Sha256>> {
+    fn signature(&self, data: &[u8]) -> CtOutput<hmac::Hmac<sha2::Sha256>> {
         let mut hasher = self.hasher.clone();
         hasher.update(data);
         hasher.finalize()


### PR DESCRIPTION
Makes sure that the outcome of #144 is applied consistently for `Basic ` usage as well.

 - [x] This change has tests (remove for doc only)
 - [x] This change has documentation

<!-- Uncomment the following paragraph to attest that You agree to the licensing

I license past and future contributions under the dual MIT/Apache-2.0 license, allowing licensees to chose either at their option.

-->

[Contributing]: CONTRIBUTING.md
