### PR TITLE
Modify async Issuer trait signature to mirror main crate

### DIFF
--- a/oxide-auth-async/Cargo.toml
+++ b/oxide-auth-async/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxide-auth-async"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Andreas Molzer <andreas.molzer@gmx.de>"]
 repository = "https://github.com/HeroicKatora/oxide-auth.git"
 

--- a/oxide-auth-async/src/primitives.rs
+++ b/oxide-auth-async/src/primitives.rs
@@ -34,15 +34,15 @@ pub trait Issuer {
 
     async fn refresh(&mut self, _: &str, _: Grant) -> Result<RefreshedToken, ()>;
 
-    async fn recover_token(&mut self, _: &str) -> Result<Option<Grant>, ()>;
+    async fn recover_token(&self, _: &str) -> Result<Option<Grant>, ()>;
 
-    async fn recover_refresh(&mut self, _: &str) -> Result<Option<Grant>, ()>;
+    async fn recover_refresh(&self, _: &str) -> Result<Option<Grant>, ()>;
 }
 
 #[async_trait]
 impl<T> Issuer for T
 where
-    T: issuer::Issuer + Send + ?Sized,
+    T: issuer::Issuer + Send + Sync + ?Sized,
 {
     async fn issue(&mut self, grant: Grant) -> Result<IssuedToken, ()> {
         issuer::Issuer::issue(self, grant)
@@ -52,11 +52,11 @@ where
         issuer::Issuer::refresh(self, token, grant)
     }
 
-    async fn recover_token(&mut self, token: &str) -> Result<Option<Grant>, ()> {
+    async fn recover_token(&self, token: &str) -> Result<Option<Grant>, ()> {
         issuer::Issuer::recover_token(self, token)
     }
 
-    async fn recover_refresh(&mut self, token: &str) -> Result<Option<Grant>, ()> {
+    async fn recover_refresh(&self, token: &str) -> Result<Option<Grant>, ()> {
         issuer::Issuer::recover_refresh(self, token)
     }
 }


### PR DESCRIPTION
This changes the signature of `oxide_auth_async::primitives::Issuer` to mirror the signature of the related trait in the parent crate.

-----------------------------------------------------------

 - [x] I have read the [contribution guidelines][Contributing]



I license past and future contributions under the dual MIT/Apache-2.0 license, allowing licensees to chose either at their option.

[Contributing]: CONTRIBUTING.md
