### PR TITLE
chore: cleanup dependencies

### DIFF
--- a/oxide-auth-actix/Cargo.toml
+++ b/oxide-auth-actix/Cargo.toml
@@ -12,15 +12,15 @@ license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]
-actix = { version = "0.12", default-features = false }
-actix-web = { version = "4.0.1", default-features = false }
+actix = { version = "0.13", default-features = false }
+actix-web = { version = "4.2.1", default-features = false }
 futures = "0.3"
 oxide-auth = { version = "0.5.0", path = "../oxide-auth" }
 serde_urlencoded = "0.7"
 url = "2"
 
 [dev-dependencies]
-base64 = "0.11"
-chrono = "0.4"
+base64 = "0.13"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 serde = "1.0"
 serde_json = "1.0"

--- a/oxide-auth-actix/examples/actix-example/Cargo.toml
+++ b/oxide-auth-actix/examples/actix-example/Cargo.toml
@@ -5,9 +5,9 @@ authors = ["Andreas Molzer <andreas.molzer@gmx.de>"]
 edition = "2018"
 
 [dependencies]
-actix = "0.12"
-actix-web = "4.0.1"
-env_logger = "0.7"
+actix = "0.13"
+actix-web = "4.2.1"
+env_logger = "0.9"
 futures = "0.3"
 oxide-auth = { version = "0.5.0", path = "./../../../oxide-auth" }
 oxide-auth-actix = { version = "0.2.0", path = "./../../" }

--- a/oxide-auth-async/Cargo.toml
+++ b/oxide-auth-async/Cargo.toml
@@ -14,9 +14,9 @@ edition = "2018"
 [dependencies]
 async-trait = "0.1.21"
 oxide-auth = { version = "0.5.0", path = "../oxide-auth" }
-base64 = "0.12"
+base64 = "0.13"
 url = "2"
-chrono = "0.4.2"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 
 [dev-dependencies]
 serde = "1.0"

--- a/oxide-auth-db/Cargo.toml
+++ b/oxide-auth-db/Cargo.toml
@@ -18,7 +18,6 @@ r2d2_redis = {version = "0.14", optional = true }
 url = "2"
 anyhow = "1.0"
 log = "0.4.8"
-log4rs = "0.10.0"
 
 
 [features]

--- a/oxide-auth-db/examples/db-example/Cargo.toml
+++ b/oxide-auth-db/examples/db-example/Cargo.toml
@@ -12,9 +12,9 @@ oxide-auth-actix = { version = "0.2.0", path = "./../../../oxide-auth-actix" }
 oxide-auth-db = { version = "0.2.0", path = "./../../", features = ["with-redis"] }
 
 anyhow = "1.0"
-actix = "0.12"
-actix-web = "4.0.1"
-env_logger = "0.7"
+actix = "0.13"
+actix-web = "4.2.1"
+env_logger = "0.9"
 futures = "0.3"
 reqwest = {version="0.11.10", features = ["blocking"]}
 r2d2_redis = {version = "0.14"}

--- a/oxide-auth/Cargo.toml
+++ b/oxide-auth/Cargo.toml
@@ -16,7 +16,7 @@ autoexamples = false
 
 [dependencies]
 base64 = "0.13"
-chrono = "0.4.2"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 hmac = "0.12.0"
 once_cell = "1.3.1"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
This changes/fixes/improves:

- bump actix 0.12 -> 0.13
- bump actix-web 4.0.1 -> 4.2.1
- chrono disable oldtime feature (to fix time cve RUSTSEC-2020-0071, at least for actix and db. rouille still has the cve but we cant change this)
- drop unused dependency log4rs

 - [x] I have read the [contribution guidelines][Contributing]
 - [ ] This change has documentation
 - [ ] Corresponds to issue (number)

I license past and future contributions under the dual MIT/Apache-2.0 license, allowing licensees to chose either at their option.