### PR TITLE
Update to smol 1.3

### DIFF
--- a/oxide-auth-async/Cargo.toml
+++ b/oxide-auth-async/Cargo.toml
@@ -12,14 +12,14 @@ license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]
-async-trait = "0.1.21"
+async-trait = "0.1.59"
 oxide-auth = { version = "0.5.0", path = "../oxide-auth" }
-base64 = "0.13"
-url = "2"
-chrono = { version = "0.4", default-features = false, features = ["clock"] }
+base64 = "0.13.1"
+url = "2.3.1"
+chrono = { version = "0.4.23", default-features = false, features = ["clock"] }
 
 [dev-dependencies]
-serde = "1.0"
-serde_derive = "1.0"
-serde_json = "1.0"
-smol = "0.1.18"
+serde = "1.0.148"
+serde_derive = "1.0.148"
+serde_json = "1.0.89"
+smol = "1.3.0"

--- a/oxide-auth-async/src/tests/access_token.rs
+++ b/oxide-auth-async/src/tests/access_token.rs
@@ -104,7 +104,7 @@ impl AccessTokenSetup {
             extensions: Extensions::new(),
         };
 
-        let authtoken = smol::run(authorizer.authorize(authrequest)).unwrap();
+        let authtoken = smol::block_on(authorizer.authorize(authrequest)).unwrap();
         registrar.register_client(client);
 
         let basic_authorization =
@@ -139,7 +139,7 @@ impl AccessTokenSetup {
             extensions: Extensions::new(),
         };
 
-        let authtoken = smol::run(authorizer.authorize(authrequest)).unwrap();
+        let authtoken = smol::block_on(authorizer.authorize(authrequest)).unwrap();
         registrar.register_client(client);
 
         let basic_authorization =
@@ -177,7 +177,7 @@ impl AccessTokenSetup {
             &mut self.issuer,
         ))
         .unwrap();
-        match smol::run(access_token_flow.execute(request)) {
+        match smol::block_on(access_token_flow.execute(request)) {
             Ok(ref response) => Self::assert_json_error_set(response),
             resp => panic!("Expected non-error reponse, got {:?}", resp),
         }
@@ -191,7 +191,7 @@ impl AccessTokenSetup {
         ))
         .unwrap();
         let response =
-            smol::run(access_token_flow.execute(request)).expect("Expected non-error reponse");
+            smol::block_on(access_token_flow.execute(request)).expect("Expected non-error reponse");
 
         self.assert_ok_access_token(response);
     }
@@ -204,7 +204,7 @@ impl AccessTokenSetup {
         ))
         .unwrap();
         flow.allow_credentials_in_body(true);
-        let response = smol::run(flow.execute(request)).expect("Expected non-error response");
+        let response = smol::block_on(flow.execute(request)).expect("Expected non-error response");
         self.assert_ok_access_token(response);
     }
 
@@ -288,7 +288,7 @@ fn access_equivalent_url() {
         extensions: Extensions::new(),
     };
 
-    let authtoken = smol::run(setup.authorizer.authorize(authrequest.clone())).unwrap();
+    let authtoken = smol::block_on(setup.authorizer.authorize(authrequest.clone())).unwrap();
     setup.test_success(CraftedRequest {
         query: None,
         urlbody: Some(
@@ -304,7 +304,7 @@ fn access_equivalent_url() {
         auth: None,
     });
 
-    let authtoken = smol::run(setup.authorizer.authorize(authrequest)).unwrap();
+    let authtoken = smol::block_on(setup.authorizer.authorize(authrequest)).unwrap();
     setup.test_success(CraftedRequest {
         query: None,
         urlbody: Some(

--- a/oxide-auth-async/src/tests/authorization.rs
+++ b/oxide-auth-async/src/tests/authorization.rs
@@ -94,7 +94,7 @@ impl AuthorizationSetup {
             &mut solicitor,
         ))
         .unwrap();
-        let response = smol::run(authorization_flow.execute(request)).expect("Should not error");
+        let response = smol::block_on(authorization_flow.execute(request)).expect("Should not error");
 
         assert_eq!(response.status, Status::Redirect);
 
@@ -112,7 +112,7 @@ impl AuthorizationSetup {
             &mut solicitor,
         ))
         .unwrap();
-        match smol::run(authorization_flow.execute(request)) {
+        match smol::block_on(authorization_flow.execute(request)) {
             Ok(ref resp) if resp.location.is_some() => panic!("Redirect without client id {:?}", resp),
             Ok(resp) => panic!("Response without client id {:?}", resp),
             Err(_) => (),
@@ -129,7 +129,7 @@ impl AuthorizationSetup {
             &mut pagehandler,
         ))
         .unwrap();
-        let response = smol::run(authorization_flow.execute(request));
+        let response = smol::block_on(authorization_flow.execute(request));
 
         let response = match response {
             Err(resp) => panic!("Expected redirect with error set: {:?}", resp),

--- a/oxide-auth-async/src/tests/refresh.rs
+++ b/oxide-auth-async/src/tests/refresh.rs
@@ -98,7 +98,7 @@ impl RefreshTokenSetup {
         };
 
         registrar.register_client(client);
-        let issued = smol::run(issuer.issue(grant)).unwrap();
+        let issued = smol::block_on(issuer.issue(grant)).unwrap();
         assert!(issued.refreshable());
         let refresh_token = issued.refresh.clone().unwrap();
 
@@ -135,7 +135,7 @@ impl RefreshTokenSetup {
         };
 
         registrar.register_client(client);
-        let issued = smol::run(issuer.issue(grant)).unwrap();
+        let issued = smol::block_on(issuer.issue(grant)).unwrap();
         assert!(issued.refreshable());
         let refresh_token = issued.refresh.clone().unwrap();
 
@@ -153,7 +153,7 @@ impl RefreshTokenSetup {
     fn assert_success(&mut self, request: CraftedRequest) -> RefreshedToken {
         let mut refresh_flow =
             RefreshFlow::prepare(RefreshTokenEndpoint::new(&self.registrar, &mut self.issuer)).unwrap();
-        let response = smol::run(refresh_flow.execute(request)).expect("Expected non-failed reponse");
+        let response = smol::block_on(refresh_flow.execute(request)).expect("Expected non-failed reponse");
         assert_eq!(response.status, Status::Ok);
         let body = match response.body {
             Some(Body::Json(body)) => body,
@@ -173,7 +173,7 @@ impl RefreshTokenSetup {
     fn assert_unauthenticated(&mut self, request: CraftedRequest) {
         let mut refresh_flow =
             RefreshFlow::prepare(RefreshTokenEndpoint::new(&self.registrar, &mut self.issuer)).unwrap();
-        let response = smol::run(refresh_flow.execute(request)).expect("Expected non-failed reponse");
+        let response = smol::block_on(refresh_flow.execute(request)).expect("Expected non-failed reponse");
         let body = self.assert_json_body(&response);
         if response.status == Status::Unauthorized {
             assert!(response.www_authenticate.is_some());
@@ -187,7 +187,7 @@ impl RefreshTokenSetup {
     fn assert_invalid(&mut self, request: CraftedRequest) {
         let mut refresh_flow =
             RefreshFlow::prepare(RefreshTokenEndpoint::new(&self.registrar, &mut self.issuer)).unwrap();
-        let response = smol::run(refresh_flow.execute(request)).expect("Expected non-failed reponse");
+        let response = smol::block_on(refresh_flow.execute(request)).expect("Expected non-failed reponse");
         let body = self.assert_json_body(&response);
         assert_eq!(response.status, Status::BadRequest);
 
@@ -199,7 +199,7 @@ impl RefreshTokenSetup {
     fn assert_invalid_grant(&mut self, request: CraftedRequest) {
         let mut refresh_flow =
             RefreshFlow::prepare(RefreshTokenEndpoint::new(&self.registrar, &mut self.issuer)).unwrap();
-        let response = smol::run(refresh_flow.execute(request)).expect("Expected non-failed reponse");
+        let response = smol::block_on(refresh_flow.execute(request)).expect("Expected non-failed reponse");
         let body = self.assert_json_body(&response);
         assert_eq!(response.status, Status::BadRequest);
 
@@ -211,7 +211,7 @@ impl RefreshTokenSetup {
     fn assert_wrong_authentication(&mut self, request: CraftedRequest) {
         let mut refresh_flow =
             RefreshFlow::prepare(RefreshTokenEndpoint::new(&self.registrar, &mut self.issuer)).unwrap();
-        let response = smol::run(refresh_flow.execute(request)).expect("Expected non-failed reponse");
+        let response = smol::block_on(refresh_flow.execute(request)).expect("Expected non-failed reponse");
         assert_eq!(response.status, Status::Unauthorized);
         assert!(response.www_authenticate.is_some());
 
@@ -247,7 +247,7 @@ impl RefreshTokenSetup {
         let mut scopes = [EXAMPLE_SCOPE.parse().unwrap()];
         let mut resource_flow =
             ResourceFlow::prepare(ResourceEndpoint::new(&mut self.issuer, &mut scopes)).unwrap();
-        smol::run(resource_flow.execute(request)).expect("Expected access allowed");
+        smol::block_on(resource_flow.execute(request)).expect("Expected access allowed");
     }
 }
 

--- a/oxide-auth-async/src/tests/resource.rs
+++ b/oxide-auth-async/src/tests/resource.rs
@@ -68,7 +68,7 @@ impl ResourceSetup {
         // Ensure that valid tokens are 16 bytes long, so we can craft an invalid one
         let mut issuer = TokenMap::new(RandomGenerator::new(16));
 
-        let authtoken = smol::run(issuer.issue(Grant {
+        let authtoken = smol::block_on(issuer.issue(Grant {
             client_id: EXAMPLE_CLIENT_ID.to_string(),
             owner_id: EXAMPLE_OWNER_ID.to_string(),
             redirect_uri: EXAMPLE_REDIRECT_URI.parse().unwrap(),
@@ -78,7 +78,7 @@ impl ResourceSetup {
         }))
         .unwrap();
 
-        let wrong_scope_token = smol::run(issuer.issue(Grant {
+        let wrong_scope_token = smol::block_on(issuer.issue(Grant {
             client_id: EXAMPLE_CLIENT_ID.to_string(),
             owner_id: EXAMPLE_OWNER_ID.to_string(),
             redirect_uri: EXAMPLE_REDIRECT_URI.parse().unwrap(),
@@ -88,7 +88,7 @@ impl ResourceSetup {
         }))
         .unwrap();
 
-        let small_scope_token = smol::run(issuer.issue(Grant {
+        let small_scope_token = smol::block_on(issuer.issue(Grant {
             client_id: EXAMPLE_CLIENT_ID.to_string(),
             owner_id: EXAMPLE_OWNER_ID.to_string(),
             redirect_uri: EXAMPLE_REDIRECT_URI.parse().unwrap(),
@@ -111,7 +111,7 @@ impl ResourceSetup {
         let mut resource_flow =
             ResourceFlow::prepare(ResourceEndpoint::new(&mut self.issuer, &mut self.resource_scope))
                 .unwrap();
-        match smol::run(resource_flow.execute(request)) {
+        match smol::block_on(resource_flow.execute(request)) {
             Ok(_) => (),
             Err(ohno) => panic!("Expected an error instead of {:?}", ohno),
         }
@@ -121,7 +121,7 @@ impl ResourceSetup {
         let mut resource_flow =
             ResourceFlow::prepare(ResourceEndpoint::new(&mut self.issuer, &mut self.resource_scope))
                 .unwrap();
-        match smol::run(resource_flow.execute(request)) {
+        match smol::block_on(resource_flow.execute(request)) {
             Ok(resp) => panic!("Expected an error instead of {:?}", resp),
             Err(_) => (),
         }


### PR DESCRIPTION
This updates smol to 1.3

 - [x] I have read the [contribution guidelines][Contributing]
 - [x] This change has tests (remove for doc only)
 - [ ] This change has documentation
 - [ ] Corresponds to issue (number)

I license past and future contributions under the dual MIT/Apache-2.0 license, allowing licensees to chose either at their option.

[Contributing]: CONTRIBUTING.md
