### PR TITLE
Version bump and fix chrono timestamp_opt warn

### DIFF
--- a/oxide-auth/Cargo.toml
+++ b/oxide-auth/Cargo.toml
@@ -15,22 +15,22 @@ license = "MIT OR Apache-2.0"
 autoexamples = false
 
 [dependencies]
-base64 = "0.13"
-chrono = { version = "0.4", default-features = false, features = ["clock"] }
-hmac = "0.12.0"
-once_cell = "1.3.1"
-serde = { version = "1.0", features = ["derive"] }
-serde_derive = "1.0"
-serde_json = "1.0"
-sha2 = "0.10.1"
+base64 = "0.13.1"
+chrono = { version = "0.4.23", default-features = false, features = ["clock"] }
+hmac = "0.12.1"
+once_cell = "1.16.0"
+serde = { version = "1.0.148", features = ["derive"] }
+serde_derive = "1.0.148"
+serde_json = "1.0.89"
+sha2 = "0.10.6"
 subtle = "2.4.1"
-rand = "0.8"
-rust-argon2 = "1.0"
-rmp-serde = "1.1"
-url = { version = "2.2.2", features = ["serde"] }
+rand = "0.8.5"
+rust-argon2 = "1.0.0"
+rmp-serde = "1.1.1"
+url = { version = "2.3.1", features = ["serde"] }
 
 [dev-dependencies]
-reqwest = { version = "0.11.10", features = ["blocking"] }
+reqwest = { version = "0.11.13", features = ["blocking"] }
 
 [package.metadata.docs.rs]
 features = []

--- a/oxide-auth/src/primitives/generator.rs
+++ b/oxide-auth/src/primitives/generator.rs
@@ -318,7 +318,7 @@ mod time_serde {
     use chrono::{TimeZone, Utc};
 
     use serde::ser::{Serializer};
-    use serde::de::{Deserialize, Deserializer};
+    use serde::de::{Deserialize, Deserializer, Error};
 
     pub fn serialize<S: Serializer>(time: &Time, serializer: S) -> Result<S::Ok, S::Error> {
         serializer.serialize_i64(time.timestamp())
@@ -326,7 +326,7 @@ mod time_serde {
 
     pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Time, D::Error> {
         let as_timestamp: i64 = <i64>::deserialize(deserializer)?;
-        Ok(Utc.timestamp(as_timestamp, 0))
+        Utc.timestamp_opt(as_timestamp, 0).single().ok_or(Error::custom("Invalid timestamp"))
     }
 }
 


### PR DESCRIPTION
This fixes timestamp deprecation warning by moving to timestamp_opt as the behavior of `timestamp()` is to panic.

 - [x] I have read the [contribution guidelines][Contributing]
 - [ ] This change has tests (remove for doc only)
 - [ ] This change has documentation
 - [ ] Corresponds to issue (number)

<!-- Uncomment the following paragraph to attest that You agree to the licensing

I license past and future contributions under the dual MIT/Apache-2.0 license, allowing licensees to chose either at their option.

-->

[Contributing]: CONTRIBUTING.md
