### PR TITLE
Fixes #152

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -75,7 +75,7 @@ of completion. These are distributed as permitted by [IETF Trust License
 [rocket]: https://crates.io/crates/rocket
 [rouille]: https://crates.io/crates/rouille
 [interactive example]: oxide-auth-actix/examples/actix-example
-[CHANGES]: Changes.md
+[CHANGES]: CHANGELOG.md
 [MIGRATION]: Migration.md
 [CONTRIBUTING]: docs/CONTRIBUTING.md
 [LICENSE-MIT]: docs/LICENSE-MIT


### PR DESCRIPTION
This changes/fixes/improves &#8230;

 - [x] I have read the [contribution guidelines][Contributing]
 - [ ] This change has tests (remove for doc only)
 - [ ] This change has documentation
 - [x] Corresponds to #152

I license past and future contributions under the dual MIT/Apache-2.0 license, allowing licensees to chose either at their option.

[Contributing]: CONTRIBUTING.md

