### PR TITLE
[FEATURE] Add client credential flow for oxide_auth_async

### DIFF
--- a/oxide-auth-async/src/code_grant.rs
+++ b/oxide-auth-async/src/code_grant.rs
@@ -44,7 +44,7 @@ pub mod refresh {
                     }
                 }
                 Requested::Authenticate { client, pass } => {
-                    let _: () = handler
+                    handler
                         .registrar()
                         .check(&client, pass.as_deref())
                         .await

--- a/oxide-auth-async/src/endpoint/authorization.rs
+++ b/oxide-auth-async/src/endpoint/authorization.rs
@@ -328,7 +328,7 @@ where
     }
 }
 
-impl<'a, R> AuthorizationRequest for WrappedRequest<R>
+impl<R> AuthorizationRequest for WrappedRequest<R>
 where
     R: WebRequest,
 {

--- a/oxide-auth-async/src/endpoint/authorization.rs
+++ b/oxide-auth-async/src/endpoint/authorization.rs
@@ -65,7 +65,7 @@ where
     inner: AuthorizationPartialInner<'a, E, R>,
 
     /// TODO: offer this in the public api instead of dropping the request.
-    _with_request: Option<Box<dyn FnOnce(R) -> () + Send>>,
+    _with_request: Option<Box<dyn FnOnce(R) + Send>>,
 }
 
 /// Result type from processing an authentication request.

--- a/oxide-auth-async/src/endpoint/client_credentials.rs
+++ b/oxide-auth-async/src/endpoint/client_credentials.rs
@@ -1,0 +1,384 @@
+use std::borrow::Cow;
+use std::str::from_utf8;
+use std::marker::PhantomData;
+
+use oxide_auth::{
+    endpoint::{
+        NormalizedParameter, QueryParameter, WebResponse, WebRequest, InnerTemplate,
+        is_authorization_method,
+    },
+    code_grant::{
+        accesstoken::ErrorDescription,
+        client_credentials::{
+            Error as TokenError, Request as TokenRequest, Error as ClientCredentialsError,
+            Request as ClientCredentialsRequest,
+        },
+        error::{AccessTokenError, AccessTokenErrorType},
+    },
+};
+
+use super::{Endpoint, OAuthError, OwnerConsent};
+use crate::{
+    primitives::{Issuer, Registrar, Authorizer},
+    code_grant::client_credentials::{
+        Extension, client_credentials, Endpoint as ClientCredentialsEndpoint,
+    },
+};
+
+/// Offers access tokens to authenticated third parties.
+///
+/// A client may request a token that provides access to their own resources.
+///
+/// Client credentials can be allowed to appear in the request body instead of being
+/// required to be passed as HTTP Basic authorization. This is not recommended and must be
+/// enabled explicitely. See [`allow_credentials_in_body`] for details.
+///
+/// [`allow_credentials_in_body`]: #method.allow_credentials_in_body
+pub struct ClientCredentialsFlow<E, R>
+where
+    E: Endpoint<R> + Send,
+    R: WebRequest,
+{
+    endpoint: WrappedToken<E, R>,
+    allow_credentials_in_body: bool,
+    allow_refresh_token: bool,
+}
+
+struct WrappedToken<E: Endpoint<R>, R: WebRequest> {
+    inner: E,
+    extension_fallback: (),
+    r_type: PhantomData<R>,
+}
+
+struct WrappedRequest<R: WebRequest> {
+    /// Original request.
+    request: PhantomData<R>,
+
+    /// The request body
+    body: NormalizedParameter,
+
+    /// The authorization tuple
+    authorization: Option<Authorization>,
+
+    /// An error if one occurred.
+    error: Option<FailParse<R::Error>>,
+
+    /// The credentials-in-body flag from the flow.
+    allow_credentials_in_body: bool,
+}
+
+struct Invalid;
+
+enum FailParse<E> {
+    Invalid,
+    Err(E),
+}
+
+struct Authorization(String, Vec<u8>);
+
+impl<E, R> ClientCredentialsFlow<E, R>
+where
+    E: Endpoint<R> + Send + Sync,
+    R: WebRequest + Send + Sync,
+    <R as WebRequest>::Error: Send + Sync,
+{
+    /// Check that the endpoint supports the necessary operations for handling requests.
+    ///
+    /// Binds the endpoint to a particular type of request that it supports, for many
+    /// implementations this is probably single type anyways.
+    ///
+    /// ## Panics
+    ///
+    /// Indirectly `execute` may panic when this flow is instantiated with an inconsistent
+    /// endpoint, for details see the documentation of `Endpoint` and `execute`. For
+    /// consistent endpoints, the panic is instead caught as an error here.
+    pub fn prepare(mut endpoint: E) -> Result<Self, E::Error> {
+        if endpoint.registrar().is_none() {
+            return Err(endpoint.error(OAuthError::PrimitiveError));
+        }
+
+        if endpoint.issuer_mut().is_none() {
+            return Err(endpoint.error(OAuthError::PrimitiveError));
+        }
+
+        Ok(ClientCredentialsFlow {
+            endpoint: WrappedToken {
+                inner: endpoint,
+                extension_fallback: (),
+                r_type: PhantomData,
+            },
+            allow_credentials_in_body: false,
+            allow_refresh_token: false,
+        })
+    }
+
+    /// Credentials in body should only be enabled if use of HTTP Basic is not possible.
+    ///
+    /// Allows the request body to contain the `client_secret` as a form parameter. This is NOT
+    /// RECOMMENDED and need not be supported. The parameters MUST NOT appear in the request URI
+    /// itself.
+    ///
+    /// Thus support is disabled by default and must be explicitely enabled.
+    pub fn allow_credentials_in_body(&mut self, allow: bool) {
+        self.allow_credentials_in_body = allow;
+    }
+
+    /// Allow the refresh token to be included in the response.
+    ///
+    /// According to [RFC-6749 Section 4.4.3][4.4.3] "A refresh token SHOULD NOT be included" in
+    /// the response for the client credentials grant. Following that recommendation, the default
+    /// behaviour of this flow is to discard any refresh token that is returned from the issuer.
+    ///
+    /// If this behaviour is not what you want (it is possible that your particular application
+    /// does have a use for a client credentials refresh token), you may enable this feature.
+    ///
+    /// [4.4.3]: https://www.rfc-editor.org/rfc/rfc6749#section-4.4.3
+    pub fn allow_refresh_token(&mut self, allow: bool) {
+        self.allow_refresh_token = allow;
+    }
+
+    /// Use the checked endpoint to check for authorization for a resource.
+    ///
+    /// ## Panics
+    ///
+    /// When the registrar, authorizer, or issuer returned by the endpoint is suddenly
+    /// `None` when previously it was `Some(_)`.
+    pub async fn execute(&mut self, mut request: R) -> Result<R::Response, E::Error> {
+        let pending = client_credentials(
+            &mut self.endpoint,
+            &WrappedRequest::new(&mut request, self.allow_credentials_in_body),
+        )
+        .await;
+
+        let pending = match pending {
+            Err(error) => {
+                return client_credentials_error(&mut self.endpoint.inner, &mut request, error)
+            }
+            Ok(pending) => pending,
+        };
+
+        let consent = self
+            .endpoint
+            .inner
+            .owner_solicitor()
+            .unwrap()
+            .check_consent(&mut request, pending.as_solicitation())
+            .await;
+
+        let owner_id = match consent {
+            OwnerConsent::Authorized(owner_id) => owner_id,
+            OwnerConsent::Error(error) => return Err(self.endpoint.inner.web_error(error)),
+            OwnerConsent::InProgress(..) => {
+                // User interaction is not permitted in the client credentials flow, so
+                // an InProgress response is invalid.
+                return Err(self.endpoint.inner.error(OAuthError::PrimitiveError));
+            }
+            OwnerConsent::Denied => {
+                let mut error = AccessTokenError::default();
+                error.set_type(AccessTokenErrorType::InvalidClient);
+                let mut json = ErrorDescription { error };
+                let mut response = self.endpoint.inner.response(
+                    &mut request,
+                    InnerTemplate::Unauthorized {
+                        error: None,
+                        access_token_error: Some(json.description()),
+                    }
+                    .into(),
+                )?;
+                response
+                    .client_error()
+                    .map_err(|err| self.endpoint.inner.web_error(err))?;
+                response
+                    .body_json(&json.to_json())
+                    .map_err(|err| self.endpoint.inner.web_error(err))?;
+                return Ok(response);
+            }
+        };
+
+        let token = match pending
+            .issue(&mut self.endpoint, owner_id, self.allow_refresh_token)
+            .await
+        {
+            Err(error) => {
+                return client_credentials_error(&mut self.endpoint.inner, &mut request, error)
+            }
+            Ok(token) => token,
+        };
+
+        let mut response = self
+            .endpoint
+            .inner
+            .response(&mut request, InnerTemplate::Ok.into())?;
+        response
+            .body_json(&token.to_json())
+            .map_err(|err| self.endpoint.inner.web_error(err))?;
+        Ok(response)
+    }
+}
+
+fn client_credentials_error<E: Endpoint<R>, R: WebRequest>(
+    endpoint: &mut E, request: &mut R, error: ClientCredentialsError,
+) -> Result<R::Response, E::Error> {
+    Ok(match error {
+        ClientCredentialsError::Ignore => return Err(endpoint.error(OAuthError::DenySilently)),
+        ClientCredentialsError::Invalid(mut json) => {
+            let mut response = endpoint.response(
+                request,
+                InnerTemplate::BadRequest {
+                    access_token_error: Some(json.description()),
+                }
+                .into(),
+            )?;
+            response.client_error().map_err(|err| endpoint.web_error(err))?;
+            response
+                .body_json(&json.to_json())
+                .map_err(|err| endpoint.web_error(err))?;
+            response
+        }
+        ClientCredentialsError::Unauthorized(mut json, scheme) => {
+            let mut response = endpoint.response(
+                request,
+                InnerTemplate::Unauthorized {
+                    error: None,
+                    access_token_error: Some(json.description()),
+                }
+                .into(),
+            )?;
+            response
+                .unauthorized(&scheme)
+                .map_err(|err| endpoint.web_error(err))?;
+            response
+                .body_json(&json.to_json())
+                .map_err(|err| endpoint.web_error(err))?;
+            response
+        }
+        ClientCredentialsError::Primitive(_) => {
+            // FIXME: give the context for restoration.
+            return Err(endpoint.error(OAuthError::PrimitiveError));
+        }
+    })
+}
+
+impl<E: Endpoint<R>, R: WebRequest> ClientCredentialsEndpoint for WrappedToken<E, R> {
+    fn registrar(&self) -> &(dyn Registrar + Sync) {
+        self.inner.registrar().unwrap()
+    }
+
+    fn authorizer(&mut self) -> &mut (dyn Authorizer + Send) {
+        self.inner.authorizer_mut().unwrap()
+    }
+
+    fn issuer(&mut self) -> &mut (dyn Issuer + Send) {
+        self.inner.issuer_mut().unwrap()
+    }
+
+    fn extension(&mut self) -> &mut (dyn Extension + Send) {
+        self.inner
+            .extension()
+            .and_then(super::Extension::client_credentials)
+            .unwrap_or(&mut self.extension_fallback)
+    }
+}
+
+impl<R: WebRequest> WrappedRequest<R> {
+    pub fn new(request: &mut R, credentials: bool) -> Self {
+        Self::new_or_fail(request, credentials).unwrap_or_else(Self::from_err)
+    }
+
+    fn new_or_fail(request: &mut R, credentials: bool) -> Result<Self, FailParse<R::Error>> {
+        // If there is a header, it must parse correctly.
+        let authorization = match request.authheader() {
+            Err(err) => return Err(FailParse::Err(err)),
+            Ok(Some(header)) => Self::parse_header(header).map(Some)?,
+            Ok(None) => None,
+        };
+
+        Ok(WrappedRequest {
+            request: PhantomData,
+            body: request
+                .urlbody()
+                .map(|body| body.into_owned())
+                .map_err(FailParse::Err)?,
+            authorization,
+            error: None,
+            allow_credentials_in_body: credentials,
+        })
+    }
+
+    fn from_err(err: FailParse<R::Error>) -> Self {
+        WrappedRequest {
+            request: PhantomData,
+            body: Default::default(),
+            authorization: None,
+            error: Some(err),
+            allow_credentials_in_body: false,
+        }
+    }
+
+    fn parse_header(header: Cow<str>) -> Result<Authorization, Invalid> {
+        let authorization = {
+            let auth_data = match is_authorization_method(&header, "Basic ") {
+                None => return Err(Invalid),
+                Some(data) => data,
+            };
+
+            let combined = match base64::decode(auth_data) {
+                Err(_) => return Err(Invalid),
+                Ok(vec) => vec,
+            };
+
+            let mut split = combined.splitn(2, |&c| c == b':');
+            let client_bin = match split.next() {
+                None => return Err(Invalid),
+                Some(client) => client,
+            };
+            let passwd = match split.next() {
+                None => return Err(Invalid),
+                Some(passwd64) => passwd64,
+            };
+
+            let client = match from_utf8(client_bin) {
+                Err(_) => return Err(Invalid),
+                Ok(client) => client,
+            };
+
+            Authorization(client.to_string(), passwd.to_vec())
+        };
+
+        Ok(authorization)
+    }
+}
+
+impl<R: WebRequest> ClientCredentialsRequest for WrappedRequest<R> {
+    fn valid(&self) -> bool {
+        self.error.is_none()
+    }
+
+    fn authorization(&self) -> Option<(Cow<str>, Cow<[u8]>)> {
+        self.authorization
+            .as_ref()
+            .map(|auth| (auth.0.as_str().into(), auth.1.as_slice().into()))
+    }
+
+    fn grant_type(&self) -> Option<Cow<str>> {
+        self.body.unique_value("grant_type")
+    }
+
+    fn scope(&self) -> Option<Cow<str>> {
+        self.body.unique_value("scope")
+    }
+
+    fn extension(&self, key: &str) -> Option<Cow<str>> {
+        self.body.unique_value(key)
+    }
+
+    fn allow_credentials_in_body(&self) -> bool {
+        self.allow_credentials_in_body
+    }
+}
+
+impl<E> From<Invalid> for FailParse<E> {
+    fn from(_: Invalid) -> Self {
+        FailParse::Invalid
+    }
+}

--- a/oxide-auth-async/src/endpoint/client_credentials.rs
+++ b/oxide-auth-async/src/endpoint/client_credentials.rs
@@ -9,10 +9,7 @@ use oxide_auth::{
     },
     code_grant::{
         accesstoken::ErrorDescription,
-        client_credentials::{
-            Request as TokenRequest, Error as ClientCredentialsError,
-            Request as ClientCredentialsRequest,
-        },
+        client_credentials::{Error as ClientCredentialsError, Request as ClientCredentialsRequest},
         error::{AccessTokenError, AccessTokenErrorType},
     },
 };
@@ -176,7 +173,7 @@ where
             OwnerConsent::Denied => {
                 let mut error = AccessTokenError::default();
                 error.set_type(AccessTokenErrorType::InvalidClient);
-                let mut json = ErrorDescription { error };
+                let mut json = ErrorDescription::new(error);
                 let mut response = self.endpoint.inner.response(
                     &mut request,
                     InnerTemplate::Unauthorized {

--- a/oxide-auth-async/src/endpoint/client_credentials.rs
+++ b/oxide-auth-async/src/endpoint/client_credentials.rs
@@ -10,7 +10,7 @@ use oxide_auth::{
     code_grant::{
         accesstoken::ErrorDescription,
         client_credentials::{
-            Error as TokenError, Request as TokenRequest, Error as ClientCredentialsError,
+            Request as TokenRequest, Error as ClientCredentialsError,
             Request as ClientCredentialsRequest,
         },
         error::{AccessTokenError, AccessTokenErrorType},

--- a/oxide-auth-async/src/endpoint/mod.rs
+++ b/oxide-auth-async/src/endpoint/mod.rs
@@ -3,10 +3,12 @@ use oxide_auth::endpoint::{OAuthError, Template, WebRequest, OwnerConsent, Solic
 
 pub use crate::code_grant::access_token::{Extension as AccessTokenExtension};
 pub use crate::code_grant::authorization::Extension as AuthorizationExtension;
+pub use crate::code_grant::client_credentials::{Extension as ClientCredentialsExtension};
 use crate::primitives::{Authorizer, Registrar, Issuer};
 
 pub mod authorization;
 pub mod access_token;
+pub mod client_credentials;
 pub mod refresh;
 pub mod resource;
 
@@ -77,6 +79,11 @@ pub trait Extension {
 
     /// The handler for access token extensions.
     fn access_token(&mut self) -> Option<&mut (dyn AccessTokenExtension + Send)> {
+        None
+    }
+
+    /// The handler for client credentials extensions.
+    fn client_credentials(&mut self) -> Option<&mut (dyn ClientCredentialsExtension + Send)> {
         None
     }
 }

--- a/oxide-auth-async/src/tests/access_token.rs
+++ b/oxide-auth-async/src/tests/access_token.rs
@@ -15,9 +15,9 @@ use crate::{
 
 use std::collections::HashMap;
 
-use base64;
+
 use chrono::{Utc, Duration};
-use serde_json;
+
 
 use super::{Body, CraftedRequest, CraftedResponse, Status, TestGenerator, ToSingleValueQuery};
 use super::defaults::*;
@@ -108,7 +108,7 @@ impl AccessTokenSetup {
         registrar.register_client(client);
 
         let basic_authorization =
-            base64::encode(&format!("{}:{}", EXAMPLE_CLIENT_ID, EXAMPLE_PASSPHRASE));
+            base64::encode(format!("{}:{}", EXAMPLE_CLIENT_ID, EXAMPLE_PASSPHRASE));
 
         AccessTokenSetup {
             registrar,
@@ -143,7 +143,7 @@ impl AccessTokenSetup {
         registrar.register_client(client);
 
         let basic_authorization =
-            base64::encode(&format!("{}:{}", EXAMPLE_CLIENT_ID, EXAMPLE_PASSPHRASE));
+            base64::encode(format!("{}:{}", EXAMPLE_CLIENT_ID, EXAMPLE_PASSPHRASE));
 
         AccessTokenSetup {
             registrar,
@@ -338,7 +338,7 @@ fn access_request_unknown_client() {
         ),
         auth: Some(
             "Basic ".to_string()
-                + &base64::encode(&format!("{}:{}", "SomeOtherClient", EXAMPLE_PASSPHRASE)),
+                + &base64::encode(format!("{}:{}", "SomeOtherClient", EXAMPLE_PASSPHRASE)),
         ),
     };
 
@@ -383,7 +383,7 @@ fn access_request_wrong_password() {
         ),
         auth: Some(
             "Basic ".to_string()
-                + &base64::encode(&format!("{}:{}", EXAMPLE_CLIENT_ID, "NotTheRightPassphrase")),
+                + &base64::encode(format!("{}:{}", EXAMPLE_CLIENT_ID, "NotTheRightPassphrase")),
         ),
     };
 
@@ -405,7 +405,7 @@ fn access_request_empty_password() {
             .iter()
             .to_single_value_query(),
         ),
-        auth: Some("Basic ".to_string() + &base64::encode(&format!("{}:{}", EXAMPLE_CLIENT_ID, ""))),
+        auth: Some("Basic ".to_string() + &base64::encode(format!("{}:{}", EXAMPLE_CLIENT_ID, ""))),
     };
 
     setup.test_simple_error(empty_password);

--- a/oxide-auth-async/src/tests/access_token.rs
+++ b/oxide-auth-async/src/tests/access_token.rs
@@ -15,9 +15,7 @@ use crate::{
 
 use std::collections::HashMap;
 
-
 use chrono::{Utc, Duration};
-
 
 use super::{Body, CraftedRequest, CraftedResponse, Status, TestGenerator, ToSingleValueQuery};
 use super::defaults::*;

--- a/oxide-auth-async/src/tests/authorization.rs
+++ b/oxide-auth-async/src/tests/authorization.rs
@@ -89,7 +89,7 @@ impl AuthorizationSetup {
     fn test_success(&mut self, request: CraftedRequest) {
         let mut solicitor = Allow(EXAMPLE_OWNER_ID.to_string());
         let mut authorization_flow = AuthorizationFlow::prepare(AuthorizationEndpoint::new(
-            &mut self.registrar,
+            &self.registrar,
             &mut self.authorizer,
             &mut solicitor,
         ))
@@ -107,7 +107,7 @@ impl AuthorizationSetup {
     fn test_silent_error(&mut self, request: CraftedRequest) {
         let mut solicitor = Allow(EXAMPLE_OWNER_ID.to_string());
         let mut authorization_flow = AuthorizationFlow::prepare(AuthorizationEndpoint::new(
-            &mut self.registrar,
+            &self.registrar,
             &mut self.authorizer,
             &mut solicitor,
         ))
@@ -124,7 +124,7 @@ impl AuthorizationSetup {
         P: OwnerSolicitor<CraftedRequest>,
     {
         let mut authorization_flow = AuthorizationFlow::prepare(AuthorizationEndpoint::new(
-            &mut self.registrar,
+            &self.registrar,
             &mut self.authorizer,
             &mut pagehandler,
         ))
@@ -142,10 +142,7 @@ impl AuthorizationSetup {
                     .query_pairs()
                     .collect::<HashMap<_, _>>()
                     .get("error")
-                    .is_some() =>
-            {
-                
-            }
+                    .is_some() => {}
             other => panic!("Expected location with error set description: {:?}", other),
         }
     }

--- a/oxide-auth-async/src/tests/authorization.rs
+++ b/oxide-auth-async/src/tests/authorization.rs
@@ -99,7 +99,7 @@ impl AuthorizationSetup {
         assert_eq!(response.status, Status::Redirect);
 
         match response.location {
-            Some(ref url) if url.as_str().find("error").is_none() => (),
+            Some(ref url) if !url.as_str().contains("error") => (),
             other => panic!("Expected successful redirect: {:?}", other),
         }
     }
@@ -144,7 +144,7 @@ impl AuthorizationSetup {
                     .get("error")
                     .is_some() =>
             {
-                ()
+                
             }
             other => panic!("Expected location with error set description: {:?}", other),
         }

--- a/oxide-auth-async/src/tests/client_credentials.rs
+++ b/oxide-auth-async/src/tests/client_credentials.rs
@@ -222,23 +222,23 @@ fn client_credentials_deny_public_client() {
     };
 
     setup.test_bad_request(public_client, Deny);
+}
 
-    #[test]
-    fn client_credentials_deny_incorrect_credentials() {
-        let mut setup = ClientCredentialsSetup::new();
-        let basic_authorization = base64::encode(format!("{}:the wrong passphrase", EXAMPLE_CLIENT_ID));
-        let wrong_credentials = CraftedRequest {
-            query: None,
-            urlbody: Some(
-                vec![("grant_type", "client_credentials")]
-                    .iter()
-                    .to_single_value_query(),
-            ),
-            auth: Some(format!("Basic {}", basic_authorization)),
-        };
+#[test]
+fn client_credentials_deny_incorrect_credentials() {
+    let mut setup = ClientCredentialsSetup::new();
+    let basic_authorization = base64::encode(format!("{}:the wrong passphrase", EXAMPLE_CLIENT_ID));
+    let wrong_credentials = CraftedRequest {
+        query: None,
+        urlbody: Some(
+            vec![("grant_type", "client_credentials")]
+                .iter()
+                .to_single_value_query(),
+        ),
+        auth: Some(format!("Basic {}", basic_authorization)),
+    };
 
-        setup.test_unauthorized(wrong_credentials, Allow(EXAMPLE_CLIENT_ID.to_owned()));
-    }
+    setup.test_unauthorized(wrong_credentials, Allow(EXAMPLE_CLIENT_ID.to_owned()));
 }
 
 #[test]

--- a/oxide-auth-async/src/tests/client_credentials.rs
+++ b/oxide-auth-async/src/tests/client_credentials.rs
@@ -1,16 +1,72 @@
-use crate::primitives::registrar::{Client, ClientMap, RegisteredUrl};
-use crate::primitives::issuer::TokenMap;
+use oxide_auth::primitives::authorizer::AuthMap;
+use oxide_auth::primitives::registrar::{Client, ClientMap, RegisteredUrl};
+use oxide_auth::primitives::issuer::TokenMap;
+use oxide_auth::{frontends::simple::endpoint::Error, endpoint::WebRequest};
 
-use crate::endpoint::{OwnerSolicitor};
+use crate::{
+    endpoint::{client_credentials::ClientCredentialsFlow, Endpoint, OwnerSolicitor},
+};
 
-use crate::frontends::simple::endpoint::client_credentials_flow;
-
-use super::{CraftedRequest, CraftedResponse, Status, TestGenerator, ToSingleValueQuery};
+use super::{CraftedRequest, Status, TestGenerator, ToSingleValueQuery};
 use super::{Allow, Deny};
 use super::defaults::*;
 
+struct ClientCredentialsEndpoint<'a> {
+    registrar: &'a ClientMap,
+    authorizer: &'a mut AuthMap<TestGenerator>,
+    issuer: &'a mut TokenMap<TestGenerator>,
+    solicitor: &'a mut (dyn OwnerSolicitor<CraftedRequest> + Send + Sync),
+}
+
+impl<'a> ClientCredentialsEndpoint<'a> {
+    fn new(
+        registrar: &'a ClientMap, authorizer: &'a mut AuthMap<TestGenerator>,
+        issuer: &'a mut TokenMap<TestGenerator>,
+        solicitor: &'a mut (dyn OwnerSolicitor<CraftedRequest> + Send + Sync),
+    ) -> Self {
+        Self {
+            registrar,
+            authorizer,
+            issuer,
+            solicitor,
+        }
+    }
+}
+
+impl<'a> Endpoint<CraftedRequest> for ClientCredentialsEndpoint<'a> {
+    type Error = Error<CraftedRequest>;
+
+    fn registrar(&self) -> Option<&(dyn crate::primitives::Registrar + Sync)> {
+        Some(self.registrar)
+    }
+    fn authorizer_mut(&mut self) -> Option<&mut (dyn crate::primitives::Authorizer + Send)> {
+        Some(self.authorizer)
+    }
+    fn issuer_mut(&mut self) -> Option<&mut (dyn crate::primitives::Issuer + Send)> {
+        Some(self.issuer)
+    }
+    fn scopes(&mut self) -> Option<&mut dyn oxide_auth::endpoint::Scopes<CraftedRequest>> {
+        None
+    }
+    fn response(
+        &mut self, _: &mut CraftedRequest, _: oxide_auth::endpoint::Template,
+    ) -> Result<<CraftedRequest as WebRequest>::Response, Self::Error> {
+        Ok(Default::default())
+    }
+    fn error(&mut self, err: oxide_auth::endpoint::OAuthError) -> Self::Error {
+        Error::OAuth(err)
+    }
+    fn web_error(&mut self, err: <CraftedRequest as WebRequest>::Error) -> Self::Error {
+        Error::Web(err)
+    }
+    fn owner_solicitor(&mut self) -> Option<&mut (dyn OwnerSolicitor<CraftedRequest> + Send)> {
+        Some(self.solicitor)
+    }
+}
+
 struct ClientCredentialsSetup {
     registrar: ClientMap,
+    authorizer: AuthMap<TestGenerator>,
     issuer: TokenMap<TestGenerator>,
     basic_authorization: String,
     allow_credentials_in_body: bool,
@@ -19,6 +75,7 @@ struct ClientCredentialsSetup {
 impl ClientCredentialsSetup {
     fn new() -> ClientCredentialsSetup {
         let mut registrar = ClientMap::new();
+        let authorizer = AuthMap::new(TestGenerator("AuthToken".to_string()));
         let issuer = TokenMap::new(TestGenerator("AuthToken".to_owned()));
 
         let client = Client::confidential(
@@ -29,9 +86,10 @@ impl ClientCredentialsSetup {
         );
         registrar.register_client(client);
         let basic_authorization =
-            base64::encode(&format!("{}:{}", EXAMPLE_CLIENT_ID, EXAMPLE_PASSPHRASE));
+            base64::encode(format!("{}:{}", EXAMPLE_CLIENT_ID, EXAMPLE_PASSPHRASE));
         ClientCredentialsSetup {
             registrar,
+            authorizer,
             issuer,
             basic_authorization,
             allow_credentials_in_body: false,
@@ -40,6 +98,7 @@ impl ClientCredentialsSetup {
 
     fn public_client() -> Self {
         let mut registrar = ClientMap::new();
+        let authorizer = AuthMap::new(TestGenerator("AuthToken".to_string()));
         let issuer = TokenMap::new(TestGenerator("AccessToken".to_owned()));
 
         let client = Client::public(
@@ -49,9 +108,10 @@ impl ClientCredentialsSetup {
         );
         registrar.register_client(client);
         let basic_authorization =
-            base64::encode(&format!("{}:{}", EXAMPLE_CLIENT_ID, EXAMPLE_PASSPHRASE));
+            base64::encode(format!("{}:{}", EXAMPLE_CLIENT_ID, EXAMPLE_PASSPHRASE));
         ClientCredentialsSetup {
             registrar,
+            authorizer,
             issuer,
             basic_authorization,
             allow_credentials_in_body: false,
@@ -60,33 +120,54 @@ impl ClientCredentialsSetup {
 
     fn test_success<S>(&mut self, request: CraftedRequest, mut solicitor: S)
     where
-        S: OwnerSolicitor<CraftedRequest>,
+        S: OwnerSolicitor<CraftedRequest> + Send + Sync,
     {
-        let mut flow = client_credentials_flow(&mut self.registrar, &mut self.issuer, &mut solicitor);
+        let mut flow = ClientCredentialsFlow::prepare(ClientCredentialsEndpoint::new(
+            &self.registrar,
+            &mut self.authorizer,
+            &mut self.issuer,
+            &mut solicitor,
+        ))
+        .unwrap();
+
         flow.allow_credentials_in_body(self.allow_credentials_in_body);
-        let response = flow.execute(request).expect("Expected non-error reponse");
+        let response = smol::block_on(flow.execute(request)).expect("Expected non-error response");
 
         assert_eq!(response.status, Status::Ok);
     }
 
     fn test_bad_request<S>(&mut self, request: CraftedRequest, mut solicitor: S)
     where
-        S: OwnerSolicitor<CraftedRequest>,
+        S: OwnerSolicitor<CraftedRequest> + Send + Sync,
     {
-        let mut flow = client_credentials_flow(&mut self.registrar, &mut self.issuer, &mut solicitor);
+        let mut flow = ClientCredentialsFlow::prepare(ClientCredentialsEndpoint::new(
+            &self.registrar,
+            &mut self.authorizer,
+            &mut self.issuer,
+            &mut solicitor,
+        ))
+        .unwrap();
+
         flow.allow_credentials_in_body(self.allow_credentials_in_body);
-        let response = flow.execute(request).expect("Expected non-error response");
+        let response = smol::block_on(flow.execute(request)).expect("Expected non-error response");
 
         assert_eq!(response.status, Status::BadRequest);
     }
 
     fn test_unauthorized<S>(&mut self, request: CraftedRequest, mut solicitor: S)
     where
-        S: OwnerSolicitor<CraftedRequest>,
+        S: OwnerSolicitor<CraftedRequest> + Send + Sync,
     {
-        let mut flow = client_credentials_flow(&mut self.registrar, &mut self.issuer, &mut solicitor);
+        let mut flow = ClientCredentialsFlow::prepare(ClientCredentialsEndpoint::new(
+            &self.registrar,
+            &mut self.authorizer,
+            &mut self.issuer,
+            &mut solicitor,
+        ))
+        .unwrap();
+
         flow.allow_credentials_in_body(self.allow_credentials_in_body);
-        let response = flow.execute(request).expect("Expected non-error response");
+        let response = smol::block_on(flow.execute(request)).expect("Expected non-error response");
 
         assert_eq!(response.status, Status::Unauthorized);
     }
@@ -141,23 +222,23 @@ fn client_credentials_deny_public_client() {
     };
 
     setup.test_bad_request(public_client, Deny);
-}
 
-#[test]
-fn client_credentials_deny_incorrect_credentials() {
-    let mut setup = ClientCredentialsSetup::new();
-    let basic_authorization = base64::encode(&format!("{}:the wrong passphrase", EXAMPLE_CLIENT_ID));
-    let wrong_credentials = CraftedRequest {
-        query: None,
-        urlbody: Some(
-            vec![("grant_type", "client_credentials")]
-                .iter()
-                .to_single_value_query(),
-        ),
-        auth: Some(format!("Basic {}", basic_authorization)),
-    };
+    #[test]
+    fn client_credentials_deny_incorrect_credentials() {
+        let mut setup = ClientCredentialsSetup::new();
+        let basic_authorization = base64::encode(format!("{}:the wrong passphrase", EXAMPLE_CLIENT_ID));
+        let wrong_credentials = CraftedRequest {
+            query: None,
+            urlbody: Some(
+                vec![("grant_type", "client_credentials")]
+                    .iter()
+                    .to_single_value_query(),
+            ),
+            auth: Some(format!("Basic {}", basic_authorization)),
+        };
 
-    setup.test_unauthorized(wrong_credentials, Allow(EXAMPLE_CLIENT_ID.to_owned()));
+        setup.test_unauthorized(wrong_credentials, Allow(EXAMPLE_CLIENT_ID.to_owned()));
+    }
 }
 
 #[test]
@@ -223,7 +304,7 @@ fn client_credentials_deny_body_missing_password() {
 fn client_credentials_deny_unknown_client() {
     // The client_id is not registered
     let mut setup = ClientCredentialsSetup::new();
-    let basic_authorization = base64::encode(&format!("{}:{}", "SomeOtherClient", EXAMPLE_PASSPHRASE));
+    let basic_authorization = base64::encode(format!("{}:{}", "SomeOtherClient", EXAMPLE_PASSPHRASE));
     let unknown_client = CraftedRequest {
         query: None,
         urlbody: Some(
@@ -236,28 +317,6 @@ fn client_credentials_deny_unknown_client() {
 
     // Do not leak the information that this is unknown. It must appear as a bad login attempt.
     setup.test_unauthorized(unknown_client, Allow("SomeOtherClient".to_owned()));
-}
-
-#[test]
-fn client_credentials_deny_body_unknown_client() {
-    let mut setup = ClientCredentialsSetup::new();
-    // The client_id is not registered
-    let unknown_client = CraftedRequest {
-        query: None,
-        urlbody: Some(
-            vec![
-                ("grant_type", "client_credentials"),
-                ("client_id", "SomeOtherClient"),
-                ("client_secret", EXAMPLE_PASSPHRASE),
-            ]
-            .iter()
-            .to_single_value_query(),
-        ),
-        auth: None,
-    };
-
-    // Do not leak the information that this is unknown. It must appear as a bad login attempt.
-    setup.test_bad_request(unknown_client, Allow("SomeOtherClient".to_owned()));
 }
 
 #[test]
@@ -304,40 +363,6 @@ fn client_duplicate_credentials_denied() {
     };
 
     setup.test_bad_request(unknown_client, Allow(EXAMPLE_OWNER_ID.to_owned()));
-}
-
-#[test]
-fn client_credentials_request_error_denied() {
-    let mut setup = ClientCredentialsSetup::new();
-    // Used in conjunction with a denying solicitor below
-    let denied_request = CraftedRequest {
-        query: None,
-        urlbody: Some(
-            vec![("grant_type", "client_credentials")]
-                .iter()
-                .to_single_value_query(),
-        ),
-        auth: Some(format!("Basic {}", setup.basic_authorization)),
-    };
-
-    setup.test_bad_request(denied_request, Deny);
-}
-
-#[test]
-fn client_credentials_request_error_unsupported_grant_type() {
-    let mut setup = ClientCredentialsSetup::new();
-    // Requesting grant with a grant_type other than client_credentials
-    let unsupported_grant_type = CraftedRequest {
-        query: None,
-        urlbody: Some(
-            vec![("grant_type", "not_client_credentials")]
-                .iter()
-                .to_single_value_query(),
-        ),
-        auth: Some(format!("Basic {}", setup.basic_authorization)),
-    };
-
-    setup.test_bad_request(unsupported_grant_type, Allow(EXAMPLE_OWNER_ID.to_owned()));
 }
 
 #[test]

--- a/oxide-auth-async/src/tests/mod.rs
+++ b/oxide-auth-async/src/tests/mod.rs
@@ -44,8 +44,7 @@ struct CraftedResponse {
 }
 
 /// An enum containing the necessary HTTP status codes.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
-#[derive(Default)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Default)]
 enum Status {
     /// Http status code 200.
     #[default]
@@ -210,8 +209,6 @@ where
             .collect()
     }
 }
-
-
 
 pub mod defaults {
     pub const EXAMPLE_CLIENT_ID: &str = "ClientId";

--- a/oxide-auth-async/src/tests/mod.rs
+++ b/oxide-auth-async/src/tests/mod.rs
@@ -45,8 +45,10 @@ struct CraftedResponse {
 
 /// An enum containing the necessary HTTP status codes.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+#[derive(Default)]
 enum Status {
     /// Http status code 200.
+    #[default]
     Ok,
 
     /// Http status code 302.
@@ -204,16 +206,12 @@ where
     V: AsRef<str> + 'r,
 {
     fn to_single_value_query(self) -> HashMap<String, Vec<String>> {
-        self.map(|&(ref k, ref v)| (k.as_ref().to_string(), vec![v.as_ref().to_string()]))
+        self.map(|(k, v)| (k.as_ref().to_string(), vec![v.as_ref().to_string()]))
             .collect()
     }
 }
 
-impl Default for Status {
-    fn default() -> Self {
-        Status::Ok
-    }
-}
+
 
 pub mod defaults {
     pub const EXAMPLE_CLIENT_ID: &str = "ClientId";
@@ -225,6 +223,7 @@ pub mod defaults {
 
 mod authorization;
 mod access_token;
+mod client_credentials;
 mod type_properties;
 mod resource;
 mod refresh;

--- a/oxide-auth-async/src/tests/refresh.rs
+++ b/oxide-auth-async/src/tests/refresh.rs
@@ -15,9 +15,7 @@ use crate::{
 
 use std::collections::HashMap;
 
-
 use chrono::{Utc, Duration};
-
 
 use super::{Body, CraftedRequest, CraftedResponse, Status, ToSingleValueQuery};
 use super::{defaults::*, resource::ResourceEndpoint};

--- a/oxide-auth-async/src/tests/refresh.rs
+++ b/oxide-auth-async/src/tests/refresh.rs
@@ -15,9 +15,9 @@ use crate::{
 
 use std::collections::HashMap;
 
-use base64;
+
 use chrono::{Utc, Duration};
-use serde_json;
+
 
 use super::{Body, CraftedRequest, CraftedResponse, Status, ToSingleValueQuery};
 use super::{defaults::*, resource::ResourceEndpoint};
@@ -103,7 +103,7 @@ impl RefreshTokenSetup {
         let refresh_token = issued.refresh.clone().unwrap();
 
         let basic_authorization =
-            base64::encode(&format!("{}:{}", EXAMPLE_CLIENT_ID, EXAMPLE_PASSPHRASE));
+            base64::encode(format!("{}:{}", EXAMPLE_CLIENT_ID, EXAMPLE_PASSPHRASE));
         let basic_authorization = format!("Basic {}", basic_authorization);
 
         RefreshTokenSetup {
@@ -302,14 +302,14 @@ fn access_valid_private() {
 fn public_private_invalid_grant() {
     let mut setup = RefreshTokenSetup::public_client();
     let client = Client::confidential(
-        "PrivateClient".into(),
+        "PrivateClient",
         RegisteredUrl::Semantic(EXAMPLE_REDIRECT_URI.parse().unwrap()),
         EXAMPLE_SCOPE.parse().unwrap(),
         EXAMPLE_PASSPHRASE.as_bytes(),
     );
     setup.registrar.register_client(client);
 
-    let basic_authorization = base64::encode(&format!("{}:{}", "PrivateClient", EXAMPLE_PASSPHRASE));
+    let basic_authorization = base64::encode(format!("{}:{}", "PrivateClient", EXAMPLE_PASSPHRASE));
     let basic_authorization = format!("Basic {}", basic_authorization);
 
     let authenticated = CraftedRequest {

--- a/oxide-auth-async/src/tests/refresh.rs
+++ b/oxide-auth-async/src/tests/refresh.rs
@@ -153,7 +153,8 @@ impl RefreshTokenSetup {
     fn assert_success(&mut self, request: CraftedRequest) -> RefreshedToken {
         let mut refresh_flow =
             RefreshFlow::prepare(RefreshTokenEndpoint::new(&self.registrar, &mut self.issuer)).unwrap();
-        let response = smol::block_on(refresh_flow.execute(request)).expect("Expected non-failed reponse");
+        let response =
+            smol::block_on(refresh_flow.execute(request)).expect("Expected non-failed reponse");
         assert_eq!(response.status, Status::Ok);
         let body = match response.body {
             Some(Body::Json(body)) => body,
@@ -173,7 +174,8 @@ impl RefreshTokenSetup {
     fn assert_unauthenticated(&mut self, request: CraftedRequest) {
         let mut refresh_flow =
             RefreshFlow::prepare(RefreshTokenEndpoint::new(&self.registrar, &mut self.issuer)).unwrap();
-        let response = smol::block_on(refresh_flow.execute(request)).expect("Expected non-failed reponse");
+        let response =
+            smol::block_on(refresh_flow.execute(request)).expect("Expected non-failed reponse");
         let body = self.assert_json_body(&response);
         if response.status == Status::Unauthorized {
             assert!(response.www_authenticate.is_some());
@@ -187,7 +189,8 @@ impl RefreshTokenSetup {
     fn assert_invalid(&mut self, request: CraftedRequest) {
         let mut refresh_flow =
             RefreshFlow::prepare(RefreshTokenEndpoint::new(&self.registrar, &mut self.issuer)).unwrap();
-        let response = smol::block_on(refresh_flow.execute(request)).expect("Expected non-failed reponse");
+        let response =
+            smol::block_on(refresh_flow.execute(request)).expect("Expected non-failed reponse");
         let body = self.assert_json_body(&response);
         assert_eq!(response.status, Status::BadRequest);
 
@@ -199,7 +202,8 @@ impl RefreshTokenSetup {
     fn assert_invalid_grant(&mut self, request: CraftedRequest) {
         let mut refresh_flow =
             RefreshFlow::prepare(RefreshTokenEndpoint::new(&self.registrar, &mut self.issuer)).unwrap();
-        let response = smol::block_on(refresh_flow.execute(request)).expect("Expected non-failed reponse");
+        let response =
+            smol::block_on(refresh_flow.execute(request)).expect("Expected non-failed reponse");
         let body = self.assert_json_body(&response);
         assert_eq!(response.status, Status::BadRequest);
 
@@ -211,7 +215,8 @@ impl RefreshTokenSetup {
     fn assert_wrong_authentication(&mut self, request: CraftedRequest) {
         let mut refresh_flow =
             RefreshFlow::prepare(RefreshTokenEndpoint::new(&self.registrar, &mut self.issuer)).unwrap();
-        let response = smol::block_on(refresh_flow.execute(request)).expect("Expected non-failed reponse");
+        let response =
+            smol::block_on(refresh_flow.execute(request)).expect("Expected non-failed reponse");
         assert_eq!(response.status, Status::Unauthorized);
         assert!(response.www_authenticate.is_some());
 

--- a/oxide-auth-async/src/tests/resource.rs
+++ b/oxide-auth-async/src/tests/resource.rs
@@ -121,9 +121,8 @@ impl ResourceSetup {
         let mut resource_flow =
             ResourceFlow::prepare(ResourceEndpoint::new(&mut self.issuer, &mut self.resource_scope))
                 .unwrap();
-        match smol::block_on(resource_flow.execute(request)) {
-            Ok(resp) => panic!("Expected an error instead of {:?}", resp),
-            Err(_) => (),
+        if let Ok(resp) = smol::block_on(resource_flow.execute(request)) {
+            panic!("Expected an error instead of {:?}", resp);
         }
     }
 }

--- a/oxide-auth-async/src/tests/type_properties.rs
+++ b/oxide-auth-async/src/tests/type_properties.rs
@@ -9,6 +9,7 @@ fn require_futures_have_send_bounds() {
     require_send(|pending, handler| {
         code_grant::authorization::Pending::authorize(pending, handler, "".into())
     });
+    require_send(code_grant::client_credentials::client_credentials);
     require_send(code_grant::refresh::refresh);
     require_send(code_grant::resource::protect);
 }

--- a/oxide-auth-axum/src/request.rs
+++ b/oxide-auth-axum/src/request.rs
@@ -2,7 +2,9 @@ use oxide_auth::frontends::dev::{NormalizedParameter, QueryParameter, WebRequest
 use axum::{
     async_trait,
     extract::{Query, Form, FromRequest, FromRequestParts},
-    http::{header, request::Parts, Request}, body::HttpBody, BoxError,
+    http::{header, request::Parts, Request},
+    body::HttpBody,
+    BoxError,
 };
 use crate::{OAuthResponse, WebError};
 use std::borrow::Cow;
@@ -111,7 +113,7 @@ where
             .await
             .ok()
             .map(|b: Form<NormalizedParameter>| b.0);
-            
+
         Ok(Self { auth, query, body })
     }
 }
@@ -119,7 +121,7 @@ where
 #[async_trait]
 impl<S> FromRequestParts<S> for OAuthResource
 where
-    S: Send + Sync
+    S: Send + Sync,
 {
     type Rejection = WebError;
 

--- a/oxide-auth/src/code_grant/accesstoken.rs
+++ b/oxide-auth/src/code_grant/accesstoken.rs
@@ -563,13 +563,13 @@ pub struct PrimitiveError {
 /// addition this enforces backend specific behaviour for obtaining or handling the access error.
 #[derive(Clone)]
 pub struct ErrorDescription {
-    pub(crate) error: AccessTokenError,
+    pub error: AccessTokenError,
 }
 
 type Result<T> = std::result::Result<T, Error>;
 
 /// Represents an access token, a refresh token and the associated scope for serialization.
-pub struct BearerToken(pub(crate) IssuedToken, pub(crate) String);
+pub struct BearerToken(pub IssuedToken, pub String);
 
 impl Error {
     /// Create invalid error type
@@ -617,7 +617,7 @@ impl Error {
 }
 
 impl PrimitiveError {
-    pub(crate) fn empty() -> Self {
+    pub fn empty() -> Self {
         PrimitiveError {
             grant: None,
             extensions: None,

--- a/oxide-auth/src/code_grant/accesstoken.rs
+++ b/oxide-auth/src/code_grant/accesstoken.rs
@@ -12,6 +12,7 @@ use crate::primitives::authorizer::Authorizer;
 use crate::primitives::issuer::{IssuedToken, Issuer};
 use crate::primitives::grant::{Extensions, Grant};
 use crate::primitives::registrar::{Registrar, RegistrarError};
+use crate::primitives::scope::Scope;
 
 /// Token Response
 #[derive(Deserialize, Serialize)]
@@ -406,7 +407,7 @@ impl AccessToken {
     }
 
     fn finish(grant: Box<Grant>, token: IssuedToken) -> BearerToken {
-        BearerToken(token, grant.scope.to_string())
+        BearerToken(token, grant.scope.clone())
     }
 }
 
@@ -563,13 +564,13 @@ pub struct PrimitiveError {
 /// addition this enforces backend specific behaviour for obtaining or handling the access error.
 #[derive(Clone)]
 pub struct ErrorDescription {
-    pub error: AccessTokenError,
+    pub(crate) error: AccessTokenError,
 }
 
 type Result<T> = std::result::Result<T, Error>;
 
 /// Represents an access token, a refresh token and the associated scope for serialization.
-pub struct BearerToken(pub IssuedToken, pub String);
+pub struct BearerToken(pub(crate) IssuedToken, pub(crate) Scope);
 
 impl Error {
     /// Create invalid error type
@@ -617,6 +618,7 @@ impl Error {
 }
 
 impl PrimitiveError {
+    /// Create a default empty error
     pub fn empty() -> Self {
         PrimitiveError {
             grant: None,
@@ -626,6 +628,11 @@ impl PrimitiveError {
 }
 
 impl ErrorDescription {
+    /// Create this from an access token error
+    pub fn new(error: AccessTokenError) -> Self {
+        Self { error }
+    }
+
     /// Convert the error into a json string, viable for being sent over a network with
     /// `application/json` encoding.
     pub fn to_json(&self) -> String {
@@ -653,7 +660,7 @@ impl BearerToken {
             refresh_token: self.0.refresh.clone(),
             token_type: Some("bearer".to_owned()),
             expires_in: Some(remaining.num_seconds()),
-            scope: Some(self.1.clone()),
+            scope: Some(self.1.to_string()),
             error: None,
         };
 
@@ -675,7 +682,7 @@ mod tests {
                 until: Utc::now(),
                 token_type: TokenType::Bearer,
             },
-            "scope".into(),
+            "scope".parse().unwrap(),
         );
 
         let json = token.to_json();
@@ -692,7 +699,7 @@ mod tests {
     fn no_refresh_encoding() {
         let token = BearerToken(
             IssuedToken::without_refresh("access".into(), Utc::now()),
-            "scope".into(),
+            "scope".parse().unwrap(),
         );
 
         let json = token.to_json();

--- a/oxide-auth/src/code_grant/client_credentials.rs
+++ b/oxide-auth/src/code_grant/client_credentials.rs
@@ -414,7 +414,7 @@ impl Pending {
             token.refresh = None;
         }
 
-        Ok(BearerToken(token, self.pre_grant.scope.to_string()))
+        Ok(BearerToken(token, self.pre_grant.scope.clone()))
     }
 }
 

--- a/oxide-auth/src/code_grant/error.rs
+++ b/oxide-auth/src/code_grant/error.rs
@@ -174,6 +174,7 @@ impl AccessTokenError {
         }
     }
 
+    /// Set error type
     pub fn set_type(&mut self, new_type: AccessTokenErrorType) {
         self.error = new_type;
     }

--- a/oxide-auth/src/code_grant/error.rs
+++ b/oxide-auth/src/code_grant/error.rs
@@ -174,7 +174,7 @@ impl AccessTokenError {
         }
     }
 
-    pub(crate) fn set_type(&mut self, new_type: AccessTokenErrorType) {
+    pub fn set_type(&mut self, new_type: AccessTokenErrorType) {
         self.error = new_type;
     }
 

--- a/oxide-auth/src/endpoint/mod.rs
+++ b/oxide-auth/src/endpoint/mod.rs
@@ -178,8 +178,8 @@ pub enum InnerTemplate<'a> {
 ///
 /// [`OwnerSolicitor`]: trait.OwnerSolicitor.html
 pub struct Solicitation<'flow> {
-    pub grant: Cow<'flow, PreGrant>,
-    pub state: Option<Cow<'flow, str>>,
+    pub(crate) grant: Cow<'flow, PreGrant>,
+    pub(crate) state: Option<Cow<'flow, str>>,
 }
 
 impl<'flow> Solicitation<'flow> {

--- a/oxide-auth/src/endpoint/mod.rs
+++ b/oxide-auth/src/endpoint/mod.rs
@@ -121,12 +121,14 @@ pub enum ResponseStatus {
 /// not derive this until this has shown unlikely but strongly requested. Please open an issue if you
 /// think the pros or cons should be evaluated differently.
 #[derive(Debug)]
-pub enum InnerTemplate<'a> {
+#[non_exhaustive]
+enum InnerTemplate<'a> {
     /// Authorization to access the resource has not been granted.
     Unauthorized {
         /// The underlying cause for denying access.
         ///
         /// The http authorization header is to be set according to this field.
+        #[allow(dead_code)]
         error: Option<ResourceError>,
 
         /// Information on an access token error.
@@ -691,6 +693,7 @@ impl<'a> From<InnerTemplate<'a>> for Template<'a> {
     }
 }
 
+/// Check if the header is an authorization method
 pub fn is_authorization_method<'h>(header: &'h str, method: &'static str) -> Option<&'h str> {
     let header_method = header.get(..method.len())?;
     if header_method.eq_ignore_ascii_case(method) {

--- a/oxide-auth/src/endpoint/mod.rs
+++ b/oxide-auth/src/endpoint/mod.rs
@@ -121,7 +121,7 @@ pub enum ResponseStatus {
 /// not derive this until this has shown unlikely but strongly requested. Please open an issue if you
 /// think the pros or cons should be evaluated differently.
 #[derive(Debug)]
-enum InnerTemplate<'a> {
+pub enum InnerTemplate<'a> {
     /// Authorization to access the resource has not been granted.
     Unauthorized {
         /// The underlying cause for denying access.
@@ -178,8 +178,8 @@ enum InnerTemplate<'a> {
 ///
 /// [`OwnerSolicitor`]: trait.OwnerSolicitor.html
 pub struct Solicitation<'flow> {
-    pub(crate) grant: Cow<'flow, PreGrant>,
-    pub(crate) state: Option<Cow<'flow, str>>,
+    pub grant: Cow<'flow, PreGrant>,
+    pub state: Option<Cow<'flow, str>>,
 }
 
 impl<'flow> Solicitation<'flow> {
@@ -691,7 +691,7 @@ impl<'a> From<InnerTemplate<'a>> for Template<'a> {
     }
 }
 
-fn is_authorization_method<'h>(header: &'h str, method: &'static str) -> Option<&'h str> {
+pub fn is_authorization_method<'h>(header: &'h str, method: &'static str) -> Option<&'h str> {
     let header_method = header.get(..method.len())?;
     if header_method.eq_ignore_ascii_case(method) {
         Some(&header[method.len()..])

--- a/oxide-auth/src/endpoint/tests/client_credentials.rs
+++ b/oxide-auth/src/endpoint/tests/client_credentials.rs
@@ -5,7 +5,7 @@ use crate::endpoint::{OwnerSolicitor};
 
 use crate::frontends::simple::endpoint::client_credentials_flow;
 
-use super::{CraftedRequest, CraftedResponse, Status, TestGenerator, ToSingleValueQuery};
+use super::{CraftedRequest, Status, TestGenerator, ToSingleValueQuery};
 use super::{Allow, Deny};
 use super::defaults::*;
 

--- a/oxide-auth/src/primitives/generator.rs
+++ b/oxide-auth/src/primitives/generator.rs
@@ -326,7 +326,7 @@ mod time_serde {
 
     pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Time, D::Error> {
         let as_timestamp: i64 = <i64>::deserialize(deserializer)?;
-        Ok(Utc.timestamp(as_timestamp, 0))
+        Ok(Utc.timestamp_opt(as_timestamp, 0).unwrap())
     }
 }
 

--- a/oxide-auth/src/primitives/issuer.rs
+++ b/oxide-auth/src/primitives/issuer.rs
@@ -9,6 +9,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use chrono::{Duration, Utc};
 
+use crate::{endpoint::PreGrant, code_grant::accesstoken::BearerToken};
 use super::Time;
 use super::grant::Grant;
 use super::generator::{TagGrant, TaggedAssertion, Assertion};
@@ -232,6 +233,11 @@ impl IssuedToken {
     /// This returns `false` if `refresh` is `None` and `true` otherwise.
     pub fn refreshable(&self) -> bool {
         self.refresh.is_some()
+    }
+
+    /// Convert this issued token to an access bearer token given a grant
+    pub fn convert_bearer_token(self, pre_grant: PreGrant) -> BearerToken {
+        BearerToken(self, pre_grant.scope)
     }
 }
 


### PR DESCRIPTION
This adds the missing `client_credentials` flow for `oxide_auth_async`. 

For both the code and test, I just pretty much copied the sync `client_credential` and tweaked it according

Some possible issues with my code:
- I could not find a standard for `use` or imports
- `cargo clippy --fix` has a lot of fixes outside `oxide-auth-async`. I did not commit those and only for `oxide-auth-async`
- I had to use an `rust-toolchain.toml` set for the nightly channel so I think we should include that.
- I had to expose some internal types (changed `pub (crate)` to `pub`) which might need some attention

 - [x] I have read the [contribution guidelines][Contributing]
 - [x] This change has tests (remove for doc only)
 - [ ] This change has documentation
 - [ ] Corresponds to issue (number)

I license past and future contributions under the dual MIT/Apache-2.0 license, allowing licensees to chose either at their option.