### PR TITLE
Add `Send` bound to trait object

### DIFF
--- a/oxide-auth-async/src/code_grant.rs
+++ b/oxide-auth-async/src/code_grant.rs
@@ -206,7 +206,7 @@ pub mod client_credentials {
         /// Use negotiated parameters to authorize a client for an owner. The endpoint SHOULD be the
         /// same endpoint as was used to create the pending request.
         pub async fn issue(
-            self, handler: &mut dyn Endpoint, owner_id: String, allow_refresh_token: bool,
+            self, handler: &mut (dyn Endpoint + Send), owner_id: String, allow_refresh_token: bool,
         ) -> Result<BearerToken, Error> {
             let pre_grant = self.pre_grant.clone();
 

--- a/oxide-auth-async/src/tests/access_token.rs
+++ b/oxide-auth-async/src/tests/access_token.rs
@@ -602,6 +602,15 @@ fn access_request_wrong_grant_type() {
 }
 
 #[test]
+fn assert_send() {
+    let mut setup = AccessTokenSetup::public_client();
+    let endpoint = AccessTokenEndpoint::new(&setup.registrar, &mut setup.authorizer, &mut setup.issuer);
+    let mut flow = AccessTokenFlow::prepare(endpoint).unwrap();
+
+    super::assert_send(&flow.execute(CraftedRequest::default()));
+}
+
+#[test]
 fn private_in_body() {
     let mut setup = AccessTokenSetup::private_client();
 

--- a/oxide-auth-async/src/tests/authorization.rs
+++ b/oxide-auth-async/src/tests/authorization.rs
@@ -149,6 +149,16 @@ impl AuthorizationSetup {
 }
 
 #[test]
+fn assert_send() {
+    let mut setup = AuthorizationSetup::new();
+    let mut solicitor = Deny;
+    let endpoint = AuthorizationEndpoint::new(&setup.registrar, &mut setup.authorizer, &mut solicitor);
+    let mut flow = AuthorizationFlow::prepare(endpoint).unwrap();
+
+    super::assert_send(&flow.execute(CraftedRequest::default()));
+}
+
+#[test]
 fn auth_success() {
     let success = CraftedRequest {
         query: Some(

--- a/oxide-auth-async/src/tests/client_credentials.rs
+++ b/oxide-auth-async/src/tests/client_credentials.rs
@@ -174,6 +174,21 @@ impl ClientCredentialsSetup {
 }
 
 #[test]
+fn assert_send() {
+    let mut setup = ClientCredentialsSetup::new();
+    let mut solicitor = Deny;
+    let endpoint = ClientCredentialsEndpoint::new(
+        &setup.registrar,
+        &mut setup.authorizer,
+        &mut setup.issuer,
+        &mut solicitor,
+    );
+
+    let mut flow = ClientCredentialsFlow::prepare(endpoint).unwrap();
+    super::assert_send(&flow.execute(CraftedRequest::default()));
+}
+
+#[test]
 fn client_credentials_success() {
     let mut setup = ClientCredentialsSetup::new();
     let success = CraftedRequest {

--- a/oxide-auth-async/src/tests/mod.rs
+++ b/oxide-auth-async/src/tests/mod.rs
@@ -210,6 +210,8 @@ where
     }
 }
 
+fn assert_send<T: Send>(_val: &T) {}
+
 pub mod defaults {
     pub const EXAMPLE_CLIENT_ID: &str = "ClientId";
     pub const EXAMPLE_OWNER_ID: &str = "Owner";

--- a/oxide-auth-async/src/tests/refresh.rs
+++ b/oxide-auth-async/src/tests/refresh.rs
@@ -297,6 +297,15 @@ fn access_valid_private() {
 }
 
 #[test]
+fn assert_send() {
+    let mut setup = RefreshTokenSetup::public_client();
+    let endpoint = RefreshTokenEndpoint::new(&setup.registrar, &mut setup.issuer);
+    let mut flow = RefreshFlow::prepare(endpoint).unwrap();
+
+    super::assert_send(&flow.execute(CraftedRequest::default()));
+}
+
+#[test]
 fn public_private_invalid_grant() {
     let mut setup = RefreshTokenSetup::public_client();
     let client = Client::confidential(

--- a/oxide-auth-async/src/tests/resource.rs
+++ b/oxide-auth-async/src/tests/resource.rs
@@ -140,6 +140,15 @@ fn resource_success() {
 }
 
 #[test]
+fn assert_send() {
+    let mut setup = ResourceSetup::new();
+    let endpoint = ResourceEndpoint::new(&mut setup.issuer, &mut setup.resource_scope);
+    let mut flow = ResourceFlow::prepare(endpoint).unwrap();
+
+    super::assert_send(&flow.execute(CraftedRequest::default()));
+}
+
+#[test]
 fn resource_no_authorization() {
     // Does not have any authorization
     let no_authorization = CraftedRequest {


### PR DESCRIPTION
This fixes the issue reported in #166 

 - [x] I have read the [contribution guidelines][Contributing]
 - [x] This change has tests (remove for doc only)
 - [x] This change has documentation
 - [x] Corresponds to issue #166 

I license past and future contributions under the dual MIT/Apache-2.0 license, allowing licensees to chose either at their option.

[Contributing]: CONTRIBUTING.md
