### PR TITLE
Implement `std::error::Error` for `ParseScopeErr`

### DIFF
--- a/oxide-auth/src/primitives/scope.rs
+++ b/oxide-auth/src/primitives/scope.rs
@@ -1,5 +1,5 @@
 //! Defines the Scope type and parsing/formatting according to the rfc.
-use std::{cmp, fmt, str};
+use std::{cmp, fmt, str, error};
 
 use std::collections::HashSet;
 use serde::{Deserialize, Serialize};
@@ -111,6 +111,8 @@ pub enum ParseScopeErr {
     /// In particular, the characters '\x22' (`"`) and '\x5c' (`\`)  are not allowed.
     InvalidCharacter(char),
 }
+
+impl error::Error for ParseScopeErr {}
 
 impl str::FromStr for Scope {
     type Err = ParseScopeErr;


### PR DESCRIPTION
This implements the `Error` trait for the `ParseScopeErr` type

 - [x] I have read the [contribution guidelines][Contributing]
 - [x] Corresponds to issue #168
<!-- - [ ] This change has tests (remove for doc only) -->

I license past and future contributions under the dual MIT/Apache-2.0 license, allowing licensees to chose either at their option.

[Contributing]: CONTRIBUTING.md