### PR TITLE
chore: upgrade to axum 0.7

### DIFF
--- a/oxide-auth-axum/Cargo.toml
+++ b/oxide-auth-axum/Cargo.toml
@@ -12,5 +12,5 @@ license = "MIT OR Apache-2.0"
 edition = "2021"
 
 [dependencies]
-axum = "0.6.1"
+axum = "0.7"
 oxide-auth = { version = "0.5", path = "../oxide-auth" }

--- a/oxide-auth-axum/src/request.rs
+++ b/oxide-auth-axum/src/request.rs
@@ -1,10 +1,8 @@
 use oxide_auth::frontends::dev::{NormalizedParameter, QueryParameter, WebRequest};
 use axum::{
     async_trait,
-    extract::{Query, Form, FromRequest, FromRequestParts},
-    http::{header, request::Parts, Request},
-    body::HttpBody,
-    BoxError,
+    extract::{Query, Form, FromRequest, FromRequestParts, Request},
+    http::{header, request::Parts},
 };
 use crate::{OAuthResponse, WebError};
 use std::borrow::Cow;
@@ -83,16 +81,13 @@ impl WebRequest for OAuthRequest {
 }
 
 #[async_trait]
-impl<S, B> FromRequest<S, B> for OAuthRequest
+impl<S> FromRequest<S> for OAuthRequest
 where
-    B: HttpBody + Send + 'static,
-    B::Data: Send,
-    B::Error: Into<BoxError>,
     S: Send + Sync,
 {
     type Rejection = WebError;
 
-    async fn from_request(req: Request<B>, state: &S) -> Result<Self, Self::Rejection> {
+    async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection> {
         let mut all_auth = req.headers().get_all(header::AUTHORIZATION).iter();
         let optional = all_auth.next();
 


### PR DESCRIPTION
axum 0.7 is stable now

https://github.com/tokio-rs/axum/releases/tag/axum-v0.7.0

 - [x] I have read the [contribution guidelines][Contributing]

<!-- Uncomment the following paragraph to attest that You agree to the licensing

I license past and future contributions under the dual MIT/Apache-2.0 license, allowing licensees to chose either at their option.

-->

[Contributing]: CONTRIBUTING.md
