### PR TITLE
Upgrade dependencies in core crates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-## [Unreleased]
+## `oxide-auth` [UNRELEASED]
+
+### Changed
+
+- Updated `base64` to v0.21
+- Updated `rust-argon2` to v2.0.0
+- The `Argon2` hasher now uses the parameters recommended by RFC-9106 for memory constrained environments
+
+## `oxide-auth-axum` v0.3.0
 
 ### Breaking 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+[profile.test]
+opt-level = 2
+
 [workspace]
 members = [
 	"oxide-auth",

--- a/oxide-auth-actix/Cargo.toml
+++ b/oxide-auth-actix/Cargo.toml
@@ -20,7 +20,7 @@ serde_urlencoded = "0.7"
 url = "2"
 
 [dev-dependencies]
-base64 = "0.13"
+base64 = "0.21"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 serde = "1.0"
 serde_json = "1.0"

--- a/oxide-auth-async/Cargo.toml
+++ b/oxide-auth-async/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 [dependencies]
 async-trait = "0.1.59"
 oxide-auth = { version = "0.5.4", path = "../oxide-auth" }
-base64 = "0.13.1"
+base64 = "0.21"
 url = "2.3.1"
 chrono = { version = "0.4.23", default-features = false, features = ["clock"] }
 

--- a/oxide-auth-async/src/endpoint/access_token.rs
+++ b/oxide-auth-async/src/endpoint/access_token.rs
@@ -1,6 +1,8 @@
 use std::str::from_utf8;
 use std::{borrow::Cow, marker::PhantomData};
 
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD;
 use oxide_auth::{
     endpoint::{QueryParameter, WebRequest, OAuthError, WebResponse, Template, NormalizedParameter},
     code_grant::accesstoken::{Error as TokenError, Request as TokenRequest},
@@ -243,7 +245,7 @@ impl<R: WebRequest> WrappedRequest<R> {
                 return Err(Invalid);
             }
 
-            let combined = match base64::decode(&header[6..]) {
+            let combined = match STANDARD.decode(&header[6..]) {
                 Err(_) => return Err(Invalid),
                 Ok(vec) => vec,
             };

--- a/oxide-auth-async/src/endpoint/client_credentials.rs
+++ b/oxide-auth-async/src/endpoint/client_credentials.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 use std::str::from_utf8;
 use std::marker::PhantomData;
 
+use base64::{engine::general_purpose::STANDARD, Engine};
 use oxide_auth::{
     endpoint::{
         NormalizedParameter, QueryParameter, WebResponse, WebRequest, Template, is_authorization_method,
@@ -308,7 +309,7 @@ impl<R: WebRequest> WrappedRequest<R> {
                 Some(data) => data,
             };
 
-            let combined = match base64::decode(auth_data) {
+            let combined = match STANDARD.decode(auth_data) {
                 Err(_) => return Err(Invalid),
                 Ok(vec) => vec,
             };

--- a/oxide-auth-async/src/endpoint/refresh.rs
+++ b/oxide-auth-async/src/endpoint/refresh.rs
@@ -1,5 +1,6 @@
 use std::{borrow::Cow, marker::PhantomData, str::from_utf8};
 
+use base64::{engine::general_purpose::STANDARD, Engine};
 use oxide_auth::{
     code_grant::refresh::{Error, Request},
     endpoint::{WebRequest, WebResponse, OAuthError, QueryParameter, Template, NormalizedParameter},
@@ -163,7 +164,7 @@ impl<'a, R: WebRequest> WrappedRequest<R> {
                 return Err(None);
             }
 
-            let combined = match base64::decode(&header[6..]) {
+            let combined = match STANDARD.decode(&header[6..]) {
                 Err(_) => return Err(None),
                 Ok(vec) => vec,
             };

--- a/oxide-auth-async/src/tests/access_token.rs
+++ b/oxide-auth-async/src/tests/access_token.rs
@@ -1,3 +1,5 @@
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD;
 use oxide_auth::primitives::authorizer::AuthMap;
 use oxide_auth::primitives::issuer::TokenMap;
 use oxide_auth::primitives::grant::{Grant, Extensions};
@@ -106,7 +108,7 @@ impl AccessTokenSetup {
         registrar.register_client(client);
 
         let basic_authorization =
-            base64::encode(format!("{}:{}", EXAMPLE_CLIENT_ID, EXAMPLE_PASSPHRASE));
+            STANDARD.encode(format!("{}:{}", EXAMPLE_CLIENT_ID, EXAMPLE_PASSPHRASE));
 
         AccessTokenSetup {
             registrar,
@@ -141,7 +143,7 @@ impl AccessTokenSetup {
         registrar.register_client(client);
 
         let basic_authorization =
-            base64::encode(format!("{}:{}", EXAMPLE_CLIENT_ID, EXAMPLE_PASSPHRASE));
+            STANDARD.encode(format!("{}:{}", EXAMPLE_CLIENT_ID, EXAMPLE_PASSPHRASE));
 
         AccessTokenSetup {
             registrar,
@@ -336,7 +338,7 @@ fn access_request_unknown_client() {
         ),
         auth: Some(
             "Basic ".to_string()
-                + &base64::encode(format!("{}:{}", "SomeOtherClient", EXAMPLE_PASSPHRASE)),
+                + &STANDARD.encode(format!("{}:{}", "SomeOtherClient", EXAMPLE_PASSPHRASE)),
         ),
     };
 
@@ -381,7 +383,7 @@ fn access_request_wrong_password() {
         ),
         auth: Some(
             "Basic ".to_string()
-                + &base64::encode(format!("{}:{}", EXAMPLE_CLIENT_ID, "NotTheRightPassphrase")),
+                + &STANDARD.encode(format!("{}:{}", EXAMPLE_CLIENT_ID, "NotTheRightPassphrase")),
         ),
     };
 
@@ -403,7 +405,7 @@ fn access_request_empty_password() {
             .iter()
             .to_single_value_query(),
         ),
-        auth: Some("Basic ".to_string() + &base64::encode(format!("{}:{}", EXAMPLE_CLIENT_ID, ""))),
+        auth: Some("Basic ".to_string() + &STANDARD.encode(format!("{}:{}", EXAMPLE_CLIENT_ID, ""))),
     };
 
     setup.test_simple_error(empty_password);

--- a/oxide-auth-async/src/tests/client_credentials.rs
+++ b/oxide-auth-async/src/tests/client_credentials.rs
@@ -1,3 +1,4 @@
+use base64::{engine::general_purpose::STANDARD, Engine};
 use oxide_auth::primitives::authorizer::AuthMap;
 use oxide_auth::primitives::registrar::{Client, ClientMap, RegisteredUrl};
 use oxide_auth::primitives::issuer::TokenMap;
@@ -86,7 +87,7 @@ impl ClientCredentialsSetup {
         );
         registrar.register_client(client);
         let basic_authorization =
-            base64::encode(format!("{}:{}", EXAMPLE_CLIENT_ID, EXAMPLE_PASSPHRASE));
+            STANDARD.encode(format!("{}:{}", EXAMPLE_CLIENT_ID, EXAMPLE_PASSPHRASE));
         ClientCredentialsSetup {
             registrar,
             authorizer,
@@ -108,7 +109,7 @@ impl ClientCredentialsSetup {
         );
         registrar.register_client(client);
         let basic_authorization =
-            base64::encode(format!("{}:{}", EXAMPLE_CLIENT_ID, EXAMPLE_PASSPHRASE));
+            STANDARD.encode(format!("{}:{}", EXAMPLE_CLIENT_ID, EXAMPLE_PASSPHRASE));
         ClientCredentialsSetup {
             registrar,
             authorizer,
@@ -242,7 +243,7 @@ fn client_credentials_deny_public_client() {
 #[test]
 fn client_credentials_deny_incorrect_credentials() {
     let mut setup = ClientCredentialsSetup::new();
-    let basic_authorization = base64::encode(format!("{}:the wrong passphrase", EXAMPLE_CLIENT_ID));
+    let basic_authorization = STANDARD.encode(format!("{}:the wrong passphrase", EXAMPLE_CLIENT_ID));
     let wrong_credentials = CraftedRequest {
         query: None,
         urlbody: Some(
@@ -319,7 +320,7 @@ fn client_credentials_deny_body_missing_password() {
 fn client_credentials_deny_unknown_client() {
     // The client_id is not registered
     let mut setup = ClientCredentialsSetup::new();
-    let basic_authorization = base64::encode(format!("{}:{}", "SomeOtherClient", EXAMPLE_PASSPHRASE));
+    let basic_authorization = STANDARD.encode(format!("{}:{}", "SomeOtherClient", EXAMPLE_PASSPHRASE));
     let unknown_client = CraftedRequest {
         query: None,
         urlbody: Some(

--- a/oxide-auth-async/src/tests/refresh.rs
+++ b/oxide-auth-async/src/tests/refresh.rs
@@ -1,3 +1,4 @@
+use base64::{engine::general_purpose::STANDARD, Engine};
 use oxide_auth::primitives::issuer::{IssuedToken, RefreshedToken, TokenMap, TokenType};
 use oxide_auth::primitives::generator::RandomGenerator;
 use oxide_auth::primitives::grant::{Grant, Extensions};
@@ -101,7 +102,7 @@ impl RefreshTokenSetup {
         let refresh_token = issued.refresh.clone().unwrap();
 
         let basic_authorization =
-            base64::encode(format!("{}:{}", EXAMPLE_CLIENT_ID, EXAMPLE_PASSPHRASE));
+            STANDARD.encode(format!("{}:{}", EXAMPLE_CLIENT_ID, EXAMPLE_PASSPHRASE));
         let basic_authorization = format!("Basic {}", basic_authorization);
 
         RefreshTokenSetup {
@@ -316,7 +317,7 @@ fn public_private_invalid_grant() {
     );
     setup.registrar.register_client(client);
 
-    let basic_authorization = base64::encode(format!("{}:{}", "PrivateClient", EXAMPLE_PASSPHRASE));
+    let basic_authorization = STANDARD.encode(format!("{}:{}", "PrivateClient", EXAMPLE_PASSPHRASE));
     let basic_authorization = format!("Basic {}", basic_authorization);
 
     let authenticated = CraftedRequest {
@@ -364,7 +365,7 @@ fn private_wrong_client_fails() {
             .iter()
             .to_single_value_query(),
         ),
-        auth: Some(format!("Basic {}", base64::encode("Wrong:AndWrong"))),
+        auth: Some(format!("Basic {}", STANDARD.encode("Wrong:AndWrong"))),
     };
 
     setup.assert_wrong_authentication(wrong_authentication);

--- a/oxide-auth-db/src/primitives/db_registrar.rs
+++ b/oxide-auth-db/src/primitives/db_registrar.rs
@@ -73,7 +73,7 @@ impl Extend<Client> for DBRegistrar {
         I: IntoIterator<Item = Client>,
     {
         iter.into_iter().for_each(|client| {
-            self.register_client(client);
+            let _ = self.register_client(client);
         })
     }
 }
@@ -196,7 +196,7 @@ mod tests {
             "client:".parse().unwrap(),
         )
         .unwrap();
-        db_registrar.register_client(client);
+        db_registrar.register_client(client).unwrap();
 
         assert_eq!(
             db_registrar
@@ -256,7 +256,7 @@ mod tests {
             "default".parse().unwrap(),
         );
 
-        oauth_service.register_client(public_client);
+        oauth_service.register_client(public_client).unwrap();
         oauth_service
             .check(public_id, None)
             .expect("Authorization of public client has changed");
@@ -272,7 +272,7 @@ mod tests {
             private_passphrase,
         );
 
-        oauth_service.register_client(private_client);
+        oauth_service.register_client(private_client).unwrap();
 
         oauth_service
             .check(private_id, Some(private_passphrase))

--- a/oxide-auth/Cargo.toml
+++ b/oxide-auth/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT OR Apache-2.0"
 autoexamples = false
 
 [dependencies]
-base64 = "0.13"
+base64 = "0.21"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 hmac = "0.12.0"
 once_cell = "1.3.1"
@@ -25,7 +25,7 @@ serde_json = "1.0"
 sha2 = "0.10.1"
 subtle = "2.4.1"
 rand = "0.8"
-rust-argon2 = "1.0"
+rust-argon2 = "2.0"
 rmp-serde = "1.1"
 url = { version = "2.2.2", features = ["serde"] }
 

--- a/oxide-auth/src/code_grant/extensions/pkce.rs
+++ b/oxide-auth/src/code_grant/extensions/pkce.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use crate::primitives::grant::{GrantExtension, Value};
 
-use base64;
+use base64::{self, engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use sha2::{Digest, Sha256};
 use subtle::ConstantTimeEq;
 
@@ -124,7 +124,7 @@ impl GrantExtension for Pkce {
 
 /// Base 64 encoding without padding
 fn b64encode(data: &[u8]) -> String {
-    base64::encode_config(data, base64::URL_SAFE_NO_PAD)
+    URL_SAFE_NO_PAD.encode(data)
 }
 
 impl Method {

--- a/oxide-auth/src/endpoint/accesstoken.rs
+++ b/oxide-auth/src/endpoint/accesstoken.rs
@@ -2,6 +2,9 @@ use std::borrow::Cow;
 use std::str::from_utf8;
 use std::marker::PhantomData;
 
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD;
+
 use crate::code_grant::accesstoken::{
     access_token, Error as TokenError, Extension, Endpoint as TokenEndpoint, Request as TokenRequest,
 };
@@ -243,7 +246,7 @@ impl<'a, R: WebRequest + 'a> WrappedRequest<'a, R> {
                 Some(data) => data,
             };
 
-            let combined = match base64::decode(auth_data) {
+            let combined = match STANDARD.decode(auth_data) {
                 Err(_) => return Err(Invalid),
                 Ok(vec) => vec,
             };

--- a/oxide-auth/src/endpoint/client_credentials.rs
+++ b/oxide-auth/src/endpoint/client_credentials.rs
@@ -2,6 +2,9 @@ use std::borrow::Cow;
 use std::str::from_utf8;
 use std::marker::PhantomData;
 
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD;
+
 use crate::code_grant::client_credentials::{
     client_credentials, Error as ClientCredentialsError, Extension,
     Endpoint as ClientCredentialsEndpoint, Request as ClientCredentialsRequest,
@@ -297,7 +300,7 @@ impl<'a, R: WebRequest + 'a> WrappedRequest<'a, R> {
                 Some(data) => data,
             };
 
-            let combined = match base64::decode(auth_data) {
+            let combined = match STANDARD.decode(auth_data) {
                 Err(_) => return Err(Invalid),
                 Ok(vec) => vec,
             };

--- a/oxide-auth/src/endpoint/refresh.rs
+++ b/oxide-auth/src/endpoint/refresh.rs
@@ -2,6 +2,9 @@ use std::borrow::Cow;
 use std::marker::PhantomData;
 use std::str::from_utf8;
 
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD;
+
 use crate::code_grant::refresh::{refresh, Error, Endpoint as RefreshEndpoint, Request};
 use crate::primitives::{registrar::Registrar, issuer::Issuer};
 use super::{
@@ -183,7 +186,7 @@ impl<'a, R: WebRequest + 'a> WrappedRequest<'a, R> {
                 Some(data) => data,
             };
 
-            let combined = match base64::decode(auth_data) {
+            let combined = match STANDARD.decode(auth_data) {
                 Err(_) => return Err(InitError::Malformed),
                 Ok(vec) => vec,
             };

--- a/oxide-auth/src/endpoint/tests/access_token.rs
+++ b/oxide-auth/src/endpoint/tests/access_token.rs
@@ -7,7 +7,8 @@ use crate::frontends::simple::endpoint::access_token_flow;
 
 use std::collections::HashMap;
 
-use base64;
+use base64::{self, Engine};
+use base64::engine::general_purpose::STANDARD;
 use chrono::{Utc, Duration};
 use serde_json;
 
@@ -48,7 +49,7 @@ impl AccessTokenSetup {
         registrar.register_client(client);
 
         let basic_authorization =
-            base64::encode(&format!("{}:{}", EXAMPLE_CLIENT_ID, EXAMPLE_PASSPHRASE));
+            STANDARD.encode(&format!("{}:{}", EXAMPLE_CLIENT_ID, EXAMPLE_PASSPHRASE));
 
         AccessTokenSetup {
             registrar,
@@ -83,7 +84,7 @@ impl AccessTokenSetup {
         registrar.register_client(client);
 
         let basic_authorization =
-            base64::encode(&format!("{}:{}", EXAMPLE_CLIENT_ID, EXAMPLE_PASSPHRASE));
+            STANDARD.encode(&format!("{}:{}", EXAMPLE_CLIENT_ID, EXAMPLE_PASSPHRASE));
 
         AccessTokenSetup {
             registrar,
@@ -284,7 +285,7 @@ fn access_request_unknown_client() {
         ),
         auth: Some(
             "Basic ".to_string()
-                + &base64::encode(&format!("{}:{}", "SomeOtherClient", EXAMPLE_PASSPHRASE)),
+                + &STANDARD.encode(&format!("{}:{}", "SomeOtherClient", EXAMPLE_PASSPHRASE)),
         ),
     };
 
@@ -329,7 +330,7 @@ fn access_request_wrong_password() {
         ),
         auth: Some(
             "Basic ".to_string()
-                + &base64::encode(&format!("{}:{}", EXAMPLE_CLIENT_ID, "NotTheRightPassphrase")),
+                + &STANDARD.encode(&format!("{}:{}", EXAMPLE_CLIENT_ID, "NotTheRightPassphrase")),
         ),
     };
 
@@ -351,7 +352,7 @@ fn access_request_empty_password() {
             .iter()
             .to_single_value_query(),
         ),
-        auth: Some("Basic ".to_string() + &base64::encode(&format!("{}:{}", EXAMPLE_CLIENT_ID, ""))),
+        auth: Some("Basic ".to_string() + &STANDARD.encode(&format!("{}:{}", EXAMPLE_CLIENT_ID, ""))),
     };
 
     setup.test_simple_error(empty_password);

--- a/oxide-auth/src/endpoint/tests/client_credentials.rs
+++ b/oxide-auth/src/endpoint/tests/client_credentials.rs
@@ -1,3 +1,6 @@
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD;
+
 use crate::primitives::registrar::{Client, ClientMap, RegisteredUrl};
 use crate::primitives::issuer::TokenMap;
 
@@ -29,7 +32,7 @@ impl ClientCredentialsSetup {
         );
         registrar.register_client(client);
         let basic_authorization =
-            base64::encode(&format!("{}:{}", EXAMPLE_CLIENT_ID, EXAMPLE_PASSPHRASE));
+            STANDARD.encode(&format!("{}:{}", EXAMPLE_CLIENT_ID, EXAMPLE_PASSPHRASE));
         ClientCredentialsSetup {
             registrar,
             issuer,
@@ -49,7 +52,7 @@ impl ClientCredentialsSetup {
         );
         registrar.register_client(client);
         let basic_authorization =
-            base64::encode(&format!("{}:{}", EXAMPLE_CLIENT_ID, EXAMPLE_PASSPHRASE));
+            STANDARD.encode(&format!("{}:{}", EXAMPLE_CLIENT_ID, EXAMPLE_PASSPHRASE));
         ClientCredentialsSetup {
             registrar,
             issuer,
@@ -146,7 +149,7 @@ fn client_credentials_deny_public_client() {
 #[test]
 fn client_credentials_deny_incorrect_credentials() {
     let mut setup = ClientCredentialsSetup::new();
-    let basic_authorization = base64::encode(&format!("{}:the wrong passphrase", EXAMPLE_CLIENT_ID));
+    let basic_authorization = STANDARD.encode(&format!("{}:the wrong passphrase", EXAMPLE_CLIENT_ID));
     let wrong_credentials = CraftedRequest {
         query: None,
         urlbody: Some(
@@ -223,7 +226,7 @@ fn client_credentials_deny_body_missing_password() {
 fn client_credentials_deny_unknown_client() {
     // The client_id is not registered
     let mut setup = ClientCredentialsSetup::new();
-    let basic_authorization = base64::encode(&format!("{}:{}", "SomeOtherClient", EXAMPLE_PASSPHRASE));
+    let basic_authorization = STANDARD.encode(&format!("{}:{}", "SomeOtherClient", EXAMPLE_PASSPHRASE));
     let unknown_client = CraftedRequest {
         query: None,
         urlbody: Some(

--- a/oxide-auth/src/endpoint/tests/refresh.rs
+++ b/oxide-auth/src/endpoint/tests/refresh.rs
@@ -5,7 +5,8 @@ use crate::primitives::registrar::{Client, ClientMap, RegisteredUrl};
 
 use std::collections::HashMap;
 
-use base64;
+use base64::{self, Engine};
+use base64::engine::general_purpose::STANDARD;
 use chrono::{Utc, Duration};
 use serde_json;
 
@@ -53,7 +54,7 @@ impl RefreshTokenSetup {
         let refresh_token = issued.refresh.clone().unwrap();
 
         let basic_authorization =
-            base64::encode(&format!("{}:{}", EXAMPLE_CLIENT_ID, EXAMPLE_PASSPHRASE));
+            STANDARD.encode(&format!("{}:{}", EXAMPLE_CLIENT_ID, EXAMPLE_PASSPHRASE));
         let basic_authorization = format!("Basic {}", basic_authorization);
 
         RefreshTokenSetup {
@@ -254,7 +255,7 @@ fn public_private_invalid_grant() {
     );
     setup.registrar.register_client(client);
 
-    let basic_authorization = base64::encode(&format!("{}:{}", "PrivateClient", EXAMPLE_PASSPHRASE));
+    let basic_authorization = STANDARD.encode(&format!("{}:{}", "PrivateClient", EXAMPLE_PASSPHRASE));
     let basic_authorization = format!("Basic {}", basic_authorization);
 
     let authenticated = CraftedRequest {
@@ -302,7 +303,7 @@ fn private_wrong_client_fails() {
             .iter()
             .to_single_value_query(),
         ),
-        auth: Some(format!("Basic {}", base64::encode("Wrong:AndWrong"))),
+        auth: Some(format!("Basic {}", STANDARD.encode("Wrong:AndWrong"))),
     };
 
     setup.assert_wrong_authentication(wrong_authentication);

--- a/oxide-auth/src/primitives/registrar.rs
+++ b/oxide-auth/src/primitives/registrar.rs
@@ -600,9 +600,11 @@ pub struct Argon2 {
 
 impl PasswordPolicy for Argon2 {
     fn store(&self, client_id: &str, passphrase: &[u8]) -> Vec<u8> {
-        let mut config = Config::default();
-        config.ad = client_id.as_bytes();
-        config.secret = &[];
+        let config = Config {
+            ad: client_id.as_bytes(),
+            secret: &[],
+            ..Config::rfc9106_low_mem()
+        };
 
         let mut salt = vec![0; 32];
         thread_rng()


### PR DESCRIPTION
This PR updates outdated dependencies of the core crates. In particular, it updates:

- `base64`
- `rust-argon2`

Updating these since these are the ones that released semver-incompatible versions.

---

I license past and future contributions under the dual MIT/Apache-2.0 license, allowing licensees to chose either at their option.

[Contributing]: CONTRIBUTING.md
