### PR TITLE
Release oxide-auth-axum 0.4.0

### DIFF
--- a/oxide-auth-axum/Cargo.toml
+++ b/oxide-auth-axum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxide-auth-axum"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Daniel Alvsåker <daniel.alvsaaker@protonmail.com>"]
 repository = "https://github.com/HeroicKatora/oxide-auth.git"
 


### PR DESCRIPTION
Already published to crates.io.