### PR TITLE
Fix a bunch of clippy lints

### DIFF
--- a/oxide-auth-actix/examples/actix-example/src/support.rs
+++ b/oxide-auth-actix/examples/actix-example/src/support.rs
@@ -4,7 +4,7 @@ mod generic;
 
 use std::collections::HashMap;
 
-pub use self::generic::{consent_page_html, open_in_browser, Client, ClientConfig, ClientError};
+pub use self::generic::{consent_page_html, open_in_browser, Client, ClientConfig};
 
 use actix_web::{
     App, dev,

--- a/oxide-auth-async/src/endpoint/client_credentials.rs
+++ b/oxide-auth-async/src/endpoint/client_credentials.rs
@@ -175,7 +175,7 @@ where
                 let mut json = ErrorDescription::new(error);
                 let mut response = self.endpoint.inner.response(
                     &mut request,
-                    Template::new_unauthorized(None, Some(json.description())).into(),
+                    Template::new_unauthorized(None, Some(json.description())),
                 )?;
 
                 response
@@ -198,10 +198,7 @@ where
             Ok(token) => token,
         };
 
-        let mut response = self
-            .endpoint
-            .inner
-            .response(&mut request, Template::new_ok().into())?;
+        let mut response = self.endpoint.inner.response(&mut request, Template::new_ok())?;
         response
             .body_json(&token.to_json())
             .map_err(|err| self.endpoint.inner.web_error(err))?;
@@ -216,7 +213,7 @@ fn client_credentials_error<E: Endpoint<R>, R: WebRequest>(
         ClientCredentialsError::Ignore => return Err(endpoint.error(OAuthError::DenySilently)),
         ClientCredentialsError::Invalid(mut json) => {
             let mut response =
-                endpoint.response(request, Template::new_bad(Some(json.description())).into())?;
+                endpoint.response(request, Template::new_bad(Some(json.description())))?;
 
             response.client_error().map_err(|err| endpoint.web_error(err))?;
             response
@@ -227,7 +224,7 @@ fn client_credentials_error<E: Endpoint<R>, R: WebRequest>(
         ClientCredentialsError::Unauthorized(mut json, scheme) => {
             let mut response = endpoint.response(
                 request,
-                Template::new_unauthorized(None, Some(json.description())).into(),
+                Template::new_unauthorized(None, Some(json.description())),
             )?;
 
             response

--- a/oxide-auth-async/src/tests/access_token.rs
+++ b/oxide-auth-async/src/tests/access_token.rs
@@ -218,7 +218,7 @@ fn access_valid_public() {
     let valid_public = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "authorization_code"),
                 ("client_id", EXAMPLE_CLIENT_ID),
                 ("code", &setup.authtoken),
@@ -240,7 +240,7 @@ fn access_valid_private() {
     let valid_public = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "authorization_code"),
                 ("code", &setup.authtoken),
                 ("redirect_uri", EXAMPLE_REDIRECT_URI),
@@ -290,7 +290,7 @@ fn access_equivalent_url() {
     setup.test_success(CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "authorization_code"),
                 ("client_id", CLIENT_ID),
                 ("code", &authtoken),
@@ -306,7 +306,7 @@ fn access_equivalent_url() {
     setup.test_success(CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "authorization_code"),
                 ("client_id", CLIENT_ID),
                 ("code", &authtoken),
@@ -326,7 +326,7 @@ fn access_request_unknown_client() {
     let unknown_client = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "authorization_code"),
                 ("code", &setup.authtoken),
                 ("redirect_uri", EXAMPLE_REDIRECT_URI),
@@ -350,7 +350,7 @@ fn access_request_wrong_authentication() {
     let wrong_authentication = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "authorization_code"),
                 ("code", &setup.authtoken),
                 ("redirect_uri", EXAMPLE_REDIRECT_URI),
@@ -371,7 +371,7 @@ fn access_request_wrong_password() {
     let wrong_password = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "authorization_code"),
                 ("code", &setup.authtoken),
                 ("redirect_uri", EXAMPLE_REDIRECT_URI),
@@ -395,7 +395,7 @@ fn access_request_empty_password() {
     let empty_password = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "authorization_code"),
                 ("code", &setup.authtoken),
                 ("redirect_uri", EXAMPLE_REDIRECT_URI),
@@ -416,7 +416,7 @@ fn access_request_multiple_client_indications() {
     let multiple_client_indications = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "authorization_code"),
                 ("client_id", EXAMPLE_CLIENT_ID),
                 ("code", &setup.authtoken),
@@ -438,7 +438,7 @@ fn access_request_public_authorization() {
     let public_authorization = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "authorization_code"),
                 ("code", &setup.authtoken),
                 ("redirect_uri", EXAMPLE_REDIRECT_URI),
@@ -459,7 +459,7 @@ fn access_request_public_missing_client() {
     let public_missing_client = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "authorization_code"),
                 ("code", &setup.authtoken),
                 ("redirect_uri", EXAMPLE_REDIRECT_URI),
@@ -480,7 +480,7 @@ fn access_request_invalid_basic() {
     let invalid_basic = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "authorization_code"),
                 ("code", &setup.authtoken),
                 ("redirect_uri", EXAMPLE_REDIRECT_URI),
@@ -501,7 +501,7 @@ fn access_request_wrong_redirection() {
     let wrong_redirection = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "authorization_code"),
                 ("code", &setup.authtoken),
                 ("redirect_uri", "https://wrong.client.example/endpoint"),
@@ -522,7 +522,7 @@ fn access_request_invalid_redirection() {
     let invalid_redirection = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "authorization_code"),
                 ("code", &setup.authtoken),
                 ("redirect_uri", "\\://"),
@@ -543,7 +543,7 @@ fn access_request_no_code() {
     let no_code = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "authorization_code"),
                 ("redirect_uri", EXAMPLE_REDIRECT_URI),
             ]
@@ -559,7 +559,7 @@ fn access_request_no_code() {
 #[test]
 fn access_request_multiple_codes() {
     let mut setup = AccessTokenSetup::private_client();
-    let mut urlbody = vec![
+    let mut urlbody = [
         ("grant_type", "authorization_code"),
         ("code", &setup.authtoken),
         ("redirect_uri", EXAMPLE_REDIRECT_URI),
@@ -587,7 +587,7 @@ fn access_request_wrong_grant_type() {
     let wrong_grant_type = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "another_grant_type"),
                 ("code", &setup.authtoken),
                 ("redirect_uri", EXAMPLE_REDIRECT_URI),
@@ -617,7 +617,7 @@ fn private_in_body() {
     let valid_public = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "authorization_code"),
                 ("code", &setup.authtoken),
                 ("redirect_uri", EXAMPLE_REDIRECT_URI),
@@ -640,7 +640,7 @@ fn unwanted_private_in_body_fails() {
     let valid_public = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "authorization_code"),
                 ("code", &setup.authtoken),
                 ("redirect_uri", EXAMPLE_REDIRECT_URI),
@@ -664,7 +664,7 @@ fn private_duplicate_authentication() {
     let valid_public = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "authorization_code"),
                 ("code", &setup.authtoken),
                 ("redirect_uri", EXAMPLE_REDIRECT_URI),

--- a/oxide-auth-async/src/tests/authorization.rs
+++ b/oxide-auth-async/src/tests/authorization.rs
@@ -162,7 +162,7 @@ fn assert_send() {
 fn auth_success() {
     let success = CraftedRequest {
         query: Some(
-            vec![
+            [
                 ("response_type", "code"),
                 ("client_id", EXAMPLE_CLIENT_ID),
                 ("redirect_uri", EXAMPLE_REDIRECT_URI),
@@ -180,7 +180,7 @@ fn auth_success() {
 #[test]
 fn auth_request_silent_missing_client() {
     let missing_client = CraftedRequest {
-        query: Some(vec![("response_type", "code")].iter().to_single_value_query()),
+        query: Some([("response_type", "code")].iter().to_single_value_query()),
         urlbody: None,
         auth: None,
     };
@@ -193,7 +193,7 @@ fn auth_request_silent_unknown_client() {
     // The client_id is not registered
     let unknown_client = CraftedRequest {
         query: Some(
-            vec![
+            [
                 ("response_type", "code"),
                 ("client_id", "SomeOtherClient"),
                 ("redirect_uri", "https://wrong.client.example/endpoint"),
@@ -213,7 +213,7 @@ fn auth_request_silent_mismatching_redirect() {
     // The redirect_uri does not match
     let mismatching_redirect = CraftedRequest {
         query: Some(
-            vec![
+            [
                 ("response_type", "code"),
                 ("client_id", EXAMPLE_CLIENT_ID),
                 ("redirect_uri", "https://wrong.client.example/endpoint"),
@@ -233,7 +233,7 @@ fn auth_request_silent_invalid_redirect() {
     // The redirect_uri is not an uri ('\' is not allowed to appear in the scheme)
     let invalid_redirect = CraftedRequest {
         query: Some(
-            vec![
+            [
                 ("response_type", "code"),
                 ("client_id", EXAMPLE_CLIENT_ID),
                 ("redirect_uri", "\\://"),
@@ -253,7 +253,7 @@ fn auth_request_error_denied() {
     // Used in conjunction with a denying authorization handler below
     let denied_request = CraftedRequest {
         query: Some(
-            vec![
+            [
                 ("response_type", "code"),
                 ("client_id", EXAMPLE_CLIENT_ID),
                 ("redirect_uri", EXAMPLE_REDIRECT_URI),
@@ -273,7 +273,7 @@ fn auth_request_error_unsupported_method() {
     // Requesting an authorization token for a method other than code
     let unsupported_method = CraftedRequest {
         query: Some(
-            vec![
+            [
                 ("response_type", "other_method"),
                 ("client_id", EXAMPLE_CLIENT_ID),
                 ("redirect_uri", EXAMPLE_REDIRECT_URI),
@@ -294,7 +294,7 @@ fn auth_request_error_malformed_scope() {
     // A scope with malformed formatting
     let malformed_scope = CraftedRequest {
         query: Some(
-            vec![
+            [
                 ("response_type", "code"),
                 ("client_id", EXAMPLE_CLIENT_ID),
                 ("redirect_uri", EXAMPLE_REDIRECT_URI),

--- a/oxide-auth-async/src/tests/client_credentials.rs
+++ b/oxide-auth-async/src/tests/client_credentials.rs
@@ -3,9 +3,7 @@ use oxide_auth::primitives::registrar::{Client, ClientMap, RegisteredUrl};
 use oxide_auth::primitives::issuer::TokenMap;
 use oxide_auth::{frontends::simple::endpoint::Error, endpoint::WebRequest};
 
-use crate::{
-    endpoint::{client_credentials::ClientCredentialsFlow, Endpoint, OwnerSolicitor},
-};
+use crate::endpoint::{client_credentials::ClientCredentialsFlow, Endpoint, OwnerSolicitor};
 
 use super::{CraftedRequest, Status, TestGenerator, ToSingleValueQuery};
 use super::{Allow, Deny};
@@ -194,7 +192,7 @@ fn client_credentials_success() {
     let success = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![("grant_type", "client_credentials")]
+            [("grant_type", "client_credentials")]
                 .iter()
                 .to_single_value_query(),
         ),
@@ -210,7 +208,7 @@ fn client_credentials_success_changed_owner() {
     let success = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![("grant_type", "client_credentials")]
+            [("grant_type", "client_credentials")]
                 .iter()
                 .to_single_value_query(),
         ),
@@ -226,7 +224,7 @@ fn client_credentials_deny_public_client() {
     let public_client = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "client_credentials"),
                 ("client_id", EXAMPLE_CLIENT_ID),
             ]
@@ -246,7 +244,7 @@ fn client_credentials_deny_incorrect_credentials() {
     let wrong_credentials = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![("grant_type", "client_credentials")]
+            [("grant_type", "client_credentials")]
                 .iter()
                 .to_single_value_query(),
         ),
@@ -262,7 +260,7 @@ fn client_credentials_deny_missing_credentials() {
     let missing_credentials = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "client_credentials"),
                 ("client_id", EXAMPLE_CLIENT_ID),
             ]
@@ -281,7 +279,7 @@ fn client_credentials_deny_unknown_client_missing_password() {
     let unknown_client = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "client_credentials"),
                 ("client_id", "SomeOtherClient"),
             ]
@@ -302,7 +300,7 @@ fn client_credentials_deny_body_missing_password() {
     let unknown_client = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "client_credentials"),
                 ("client_id", EXAMPLE_CLIENT_ID),
             ]
@@ -323,7 +321,7 @@ fn client_credentials_deny_unknown_client() {
     let unknown_client = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![("grant_type", "client_credentials")]
+            [("grant_type", "client_credentials")]
                 .iter()
                 .to_single_value_query(),
         ),
@@ -343,7 +341,7 @@ fn client_body_credentials() {
     let unknown_client = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "client_credentials"),
                 ("client_id", EXAMPLE_CLIENT_ID),
                 ("client_secret", EXAMPLE_PASSPHRASE),
@@ -366,7 +364,7 @@ fn client_duplicate_credentials_denied() {
     let unknown_client = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "client_credentials"),
                 ("client_id", EXAMPLE_CLIENT_ID),
                 ("client_secret", EXAMPLE_PASSPHRASE),
@@ -387,7 +385,7 @@ fn client_credentials_request_error_malformed_scope() {
     let malformed_scope = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "client_credentials"),
                 ("scope", "\"no quotes (0x22) allowed\""),
             ]

--- a/oxide-auth-async/src/tests/refresh.rs
+++ b/oxide-auth-async/src/tests/refresh.rs
@@ -3,14 +3,14 @@ use oxide_auth::primitives::generator::RandomGenerator;
 use oxide_auth::primitives::grant::{Grant, Extensions};
 use oxide_auth::{
     code_grant::accesstoken::TokenResponse,
-    endpoint::{WebRequest},
+    endpoint::WebRequest,
     primitives::registrar::{Client, ClientMap, RegisteredUrl},
     frontends::simple::endpoint::Error,
 };
 
 use crate::{
     endpoint::{refresh::RefreshFlow, Endpoint, resource::ResourceFlow},
-    primitives::{Issuer},
+    primitives::Issuer,
 };
 
 use std::collections::HashMap;
@@ -261,7 +261,7 @@ fn access_valid_public() {
     let valid_public = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "refresh_token"),
                 ("refresh_token", &setup.refresh_token),
             ]
@@ -282,7 +282,7 @@ fn access_valid_private() {
     let valid_private = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "refresh_token"),
                 ("refresh_token", &setup.refresh_token),
             ]
@@ -322,7 +322,7 @@ fn public_private_invalid_grant() {
     let authenticated = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "refresh_token"),
                 ("refresh_token", &setup.refresh_token),
             ]
@@ -342,7 +342,7 @@ fn private_wrong_client_fails() {
     let valid_public = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "refresh_token"),
                 ("refresh_token", &setup.refresh_token),
             ]
@@ -357,7 +357,7 @@ fn private_wrong_client_fails() {
     let wrong_authentication = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "refresh_token"),
                 ("refresh_token", &setup.refresh_token),
             ]
@@ -377,7 +377,7 @@ fn invalid_request() {
     let bad_base64 = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "refresh_token"),
                 ("refresh_token", &setup.refresh_token),
             ]
@@ -391,11 +391,7 @@ fn invalid_request() {
 
     let no_token = CraftedRequest {
         query: None,
-        urlbody: Some(
-            vec![("grant_type", "refresh_token")]
-                .iter()
-                .to_single_value_query(),
-        ),
+        urlbody: Some([("grant_type", "refresh_token")].iter().to_single_value_query()),
         auth: Some(setup.basic_authorization.clone()),
     };
 
@@ -409,7 +405,7 @@ fn public_invalid_token() {
     let valid_public = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "refresh_token"),
                 ("refresh_token", "not_the_issued_token"),
             ]
@@ -429,7 +425,7 @@ fn private_invalid_token() {
     let valid_private = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "refresh_token"),
                 ("refresh_token", "not_the_issued_token"),
             ]

--- a/oxide-auth-db/examples/db-example/src/main.rs
+++ b/oxide-auth-db/examples/db-example/src/main.rs
@@ -85,7 +85,7 @@ async fn index(
     }
 }
 
-async fn start_browser() -> () {
+async fn start_browser() {
     let _ = thread::spawn(support::open_in_browser);
 }
 
@@ -167,9 +167,9 @@ impl State {
         }
     }
 
-    pub fn with_solicitor<'a, S>(
-        &'a mut self, solicitor: S,
-    ) -> impl Endpoint<OAuthRequest, Error = WebError> + 'a
+    pub fn with_solicitor<S>(
+        &mut self, solicitor: S,
+    ) -> impl Endpoint<OAuthRequest, Error = WebError> + '_
     where
         S: OwnerSolicitor<OAuthRequest> + 'static,
     {
@@ -206,7 +206,7 @@ where
                         OAuthResponse::ok()
                             .content_type("text/html")
                             .unwrap()
-                            .body(&crate::support::consent_page_html("/authorize".into(), pre_grant)),
+                            .body(&crate::support::consent_page_html("/authorize", pre_grant)),
                     )
                 });
 

--- a/oxide-auth-db/examples/db-example/src/support.rs
+++ b/oxide-auth-db/examples/db-example/src/support.rs
@@ -4,7 +4,7 @@ mod generic;
 
 use std::collections::HashMap;
 
-pub use self::generic::{consent_page_html, open_in_browser, Client, ClientConfig, ClientError};
+pub use self::generic::{consent_page_html, open_in_browser, Client, ClientConfig};
 
 use actix_web::App;
 use actix_web::*;

--- a/oxide-auth-db/src/db_service/redis.rs
+++ b/oxide-auth-db/src/db_service/redis.rs
@@ -64,7 +64,7 @@ impl StringfiedEncodedClient {
         };
 
         Ok(EncodedClient {
-            client_id: (&self.client_id).parse().unwrap(),
+            client_id: self.client_id.parse().unwrap(),
             redirect_uri,
             additional_redirect_uris,
             default_scope: Scope::from_str(
@@ -151,7 +151,7 @@ impl OauthClientDBRepository for RedisDataSource {
         let mut r = self.pool.get()?;
         let client_str = r.get::<&str, String>(&(self.client_prefix.to_owned() + id))?;
         let stringfied_client = serde_json::from_str::<StringfiedEncodedClient>(&client_str)?;
-        Ok(stringfied_client.to_encoded_client()?)
+        stringfied_client.to_encoded_client()
     }
 
     fn regist_from_encoded_client(&self, client: EncodedClient) -> anyhow::Result<()> {

--- a/oxide-auth-db/src/lib.rs
+++ b/oxide-auth-db/src/lib.rs
@@ -5,9 +5,6 @@ pub mod primitives;
 fn requires_redis_and_should_skip() -> bool {
     match std::env::var("OXIDE_AUTH_SKIP_REDIS") {
         Err(_) => false,
-        Ok(st) => match st.as_str() {
-            "1" | "yes" => true,
-            _ => false,
-        },
+        Ok(st) => matches!(st.as_str(), "1" | "yes"),
     }
 }

--- a/oxide-auth-iron/examples/iron.rs
+++ b/oxide-auth-iron/examples/iron.rs
@@ -6,7 +6,7 @@ extern crate router;
 use std::sync::{Arc, Mutex};
 use std::thread::spawn;
 
-use iron::{Iron, Request, Response};
+use iron::{Iron, Request, Response, IronError};
 use iron::headers::ContentType;
 use iron::status::Status;
 use iron::middleware::Handler;
@@ -44,7 +44,7 @@ fn main_router() -> impl Handler + 'static {
                 .execute(request.into())
                 .map_err(|e| {
                     let e: OAuthError = e.into();
-                    e.into()
+                    IronError::from(e)
                 })?;
             Ok(response.into())
         },
@@ -61,7 +61,7 @@ fn main_router() -> impl Handler + 'static {
                 .execute(request.into())
                 .map_err(|e| {
                     let e: OAuthError = e.into();
-                    e.into()
+                    IronError::from(e)
                 })?;
             Ok(response.into())
         },
@@ -77,7 +77,7 @@ fn main_router() -> impl Handler + 'static {
                 .execute(request.into())
                 .map_err(|e| {
                     let e: OAuthError = e.into();
-                    e.into()
+                    IronError::from(e)
                 })?;
             Ok(response.into())
         },

--- a/oxide-auth-iron/src/lib.rs
+++ b/oxide-auth-iron/src/lib.rs
@@ -181,9 +181,9 @@ impl<'a, 'b, 'c: 'b> From<&'a mut Request<'b, 'c>> for OAuthRequest<'a, 'b, 'c> 
     }
 }
 
-impl<'a, 'b, 'c: 'b> Into<&'a mut Request<'b, 'c>> for OAuthRequest<'a, 'b, 'c> {
-    fn into(self) -> &'a mut Request<'b, 'c> {
-        self.0
+impl<'a, 'b, 'c: 'b> From<OAuthRequest<'a, 'b, 'c>> for &'a mut Request<'b, 'c> {
+    fn from(value: OAuthRequest<'a, 'b, 'c>) -> Self {
+        value.0
     }
 }
 
@@ -193,9 +193,9 @@ impl From<Response> for OAuthResponse {
     }
 }
 
-impl Into<Response> for OAuthResponse {
-    fn into(self) -> Response {
-        self.0
+impl From<OAuthResponse> for Response {
+    fn from(value: OAuthResponse) -> Self {
+        value.0
     }
 }
 
@@ -222,8 +222,8 @@ impl From<IronError> for OAuthError {
     }
 }
 
-impl Into<IronError> for OAuthError {
-    fn into(self) -> IronError {
-        self.0
+impl From<OAuthError> for IronError {
+    fn from(value: OAuthError) -> Self {
+        value.0
     }
 }

--- a/oxide-auth-rocket/src/lib.rs
+++ b/oxide-auth-rocket/src/lib.rs
@@ -31,7 +31,7 @@ pub struct OAuthRequest<'r> {
 /// Response type for Rocket OAuth requests
 ///
 /// A simple wrapper type around a simple `rocket::Response<'r>` that implements `WebResponse`.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct OAuthResponse<'r>(Response<'r>);
 
 /// Request error at the http layer.
@@ -74,7 +74,7 @@ impl<'r> OAuthRequest<'r> {
         let optional = all_auth.next();
 
         // Duplicate auth header, just treat it as no authorization.
-        let auth = if let Some(_) = all_auth.next() {
+        let auth = if all_auth.next().is_some() {
             None
         } else {
             optional.map(str::to_owned)
@@ -139,7 +139,7 @@ impl<'r> WebRequest for OAuthRequest<'r> {
     }
 
     fn authheader(&mut self) -> Result<Option<Cow<str>>, Self::Error> {
-        Ok(self.auth.as_ref().map(String::as_str).map(Cow::Borrowed))
+        Ok(self.auth.as_deref().map(Cow::Borrowed))
     }
 }
 
@@ -205,20 +205,14 @@ impl<'r> Responder<'r> for WebError {
     }
 }
 
-impl<'r> Default for OAuthResponse<'r> {
-    fn default() -> Self {
-        OAuthResponse(Default::default())
-    }
-}
-
 impl<'r> From<Response<'r>> for OAuthResponse<'r> {
     fn from(r: Response<'r>) -> Self {
         OAuthResponse::from_response(r)
     }
 }
 
-impl<'r> Into<Response<'r>> for OAuthResponse<'r> {
-    fn into(self) -> Response<'r> {
-        self.0
+impl<'r> From<OAuthResponse<'r>> for Response<'r> {
+    fn from(value: OAuthResponse<'r>) -> Self {
+        value.0
     }
 }

--- a/oxide-auth-rouille/examples/rouille.rs
+++ b/oxide-auth-rouille/examples/rouille.rs
@@ -136,12 +136,12 @@ here</a> to begin the authorization process.
 /// the flow.
 fn solicitor(request: &mut Request, grant: Solicitation<'_>) -> OwnerConsent<OAuthResponse> {
     if request.method() == "GET" {
-        let text = support::consent_page_html("/authorize".into(), grant);
+        let text = support::consent_page_html("/authorize", grant);
         let response = Response::html(text);
         OwnerConsent::InProgress(response.into())
     } else if request.method() == "POST" {
         // No real user authentication is done here, in production you MUST use session keys or equivalent
-        if let Some(_) = request.get_param("allow") {
+        if request.get_param("allow").is_some() {
             OwnerConsent::Authorized("dummy user".to_string())
         } else {
             OwnerConsent::Denied

--- a/oxide-auth-rouille/src/lib.rs
+++ b/oxide-auth-rouille/src/lib.rs
@@ -9,7 +9,6 @@ use std::borrow::Cow;
 
 use oxide_auth::endpoint::{QueryParameter, WebRequest, WebResponse};
 
-use rouille;
 use url::Url;
 
 // In the spirit of simplicity, this module does not implement any wrapper structures.  In order to

--- a/oxide-auth/src/code_grant/authorization.rs
+++ b/oxide-auth/src/code_grant/authorization.rs
@@ -170,7 +170,7 @@ impl Authorization {
     }
 
     /// Go to next state
-    pub fn advance<'req>(&mut self, input: Input<'req>) -> Output<'_> {
+    pub fn advance(&mut self, input: Input<'_>) -> Output<'_> {
         self.state = match (self.take(), input) {
             (current, Input::None) => current,
             (
@@ -207,7 +207,7 @@ impl Authorization {
             },
             AuthorizationState::Extending { .. } => Output::Extend,
             AuthorizationState::Negotiating { bound_client } => Output::Negotiate {
-                bound_client: &bound_client,
+                bound_client,
                 scope: self.scope.clone(),
             },
             AuthorizationState::Pending {
@@ -565,11 +565,11 @@ impl Error {
     }
 }
 
-impl Into<Url> for ErrorUrl {
+impl From<ErrorUrl> for Url {
     /// Finalize the error url by saving its parameters in the query part of the redirect_uri
-    fn into(self) -> Url {
-        let mut url = self.base_uri;
-        url.query_pairs_mut().extend_pairs(self.error.into_iter());
+    fn from(value: ErrorUrl) -> Self {
+        let mut url = value.base_uri;
+        url.query_pairs_mut().extend_pairs(value.error);
         url
     }
 }

--- a/oxide-auth/src/code_grant/error.rs
+++ b/oxide-auth/src/code_grant/error.rs
@@ -281,10 +281,10 @@ impl IntoIterator for &'_ AuthorizationError {
     fn into_iter(self) -> Self::IntoIter {
         let mut vec = vec![("error", Cow::Borrowed(self.error.description()))];
         if let Some(description) = &self.description {
-            vec.push(("description", description.clone().to_owned()));
+            vec.push(("description", description.clone()));
         }
         if let Some(uri) = &self.uri {
-            vec.push(("uri", uri.clone().to_owned()));
+            vec.push(("uri", uri.clone()));
         }
         vec.into_iter()
     }
@@ -314,10 +314,10 @@ impl IntoIterator for &'_ AccessTokenError {
     fn into_iter(self) -> Self::IntoIter {
         let mut vec = vec![("error", Cow::Borrowed(self.error.description()))];
         if let Some(description) = &self.description {
-            vec.push(("description", description.clone().to_owned()));
+            vec.push(("description", description.clone()));
         }
         if let Some(uri) = &self.uri {
-            vec.push(("uri", uri.clone().to_owned()));
+            vec.push(("uri", uri.clone()));
         }
         vec.into_iter()
     }

--- a/oxide-auth/src/code_grant/refresh.rs
+++ b/oxide-auth/src/code_grant/refresh.rs
@@ -237,7 +237,7 @@ impl Refresh {
     ///
     /// The provided `Input` needs to fulfill the *previous* `Output` request. See their
     /// documentation for more information.
-    pub fn advance<'req>(&mut self, input: Input<'req>) -> Output<'_> {
+    pub fn advance(&mut self, input: Input<'_>) -> Output<'_> {
         // Run the next state transition if we got the right input. Errors that happen will be
         // stored as a inescapable error state.
         match (self.take(), input) {
@@ -301,7 +301,7 @@ impl Refresh {
                 client: &grant.client_id,
                 pass: None,
             },
-            RefreshState::Recovering { token, .. } => Output::RecoverRefresh { token: &token },
+            RefreshState::Recovering { token, .. } => Output::RecoverRefresh { token },
             RefreshState::Issuing { token, grant, .. } => Output::Refresh {
                 token,
                 grant: grant.clone(),
@@ -358,14 +358,13 @@ pub fn refresh(handler: &mut dyn Endpoint, request: &dyn Request) -> Result<Bear
                 }
             }
             Requested::Authenticate { client, pass } => {
-                let _: () =
-                    handler
-                        .registrar()
-                        .check(&client, pass.as_deref())
-                        .map_err(|err| match err {
-                            RegistrarError::PrimitiveError => Error::Primitive,
-                            RegistrarError::Unspecified => Error::unauthorized("basic"),
-                        })?;
+                handler
+                    .registrar()
+                    .check(&client, pass.as_deref())
+                    .map_err(|err| match err {
+                        RegistrarError::PrimitiveError => Error::Primitive,
+                        RegistrarError::Unspecified => Error::unauthorized("basic"),
+                    })?;
                 Input::Authenticated {
                     scope: request.scope(),
                 }

--- a/oxide-auth/src/endpoint/mod.rs
+++ b/oxide-auth/src/endpoint/mod.rs
@@ -47,7 +47,7 @@ pub use crate::primitives::issuer::Issuer;
 pub use crate::primitives::registrar::Registrar;
 pub use crate::primitives::scope::Scope;
 
-use crate::code_grant::resource::{Error as ResourceError};
+use crate::code_grant::resource::Error as ResourceError;
 use crate::code_grant::error::{AuthorizationError, AccessTokenError};
 
 use url::Url;
@@ -209,10 +209,7 @@ impl<'flow> Solicitation<'flow> {
     /// This will need to be provided to the response back to the client so it must be preserved
     /// across a redirect or a consent screen presented by the user agent.
     pub fn state(&self) -> Option<&str> {
-        match self.state {
-            None => None,
-            Some(ref state) => Some(&state),
-        }
+        self.state.as_deref()
     }
 
     /// Create a new solicitation request from a pre grant.

--- a/oxide-auth/src/endpoint/query.rs
+++ b/oxide-auth/src/endpoint/query.rs
@@ -220,7 +220,7 @@ where
     fn normalize(&self) -> NormalizedParameter {
         let mut params = NormalizedParameter::default();
         self.iter()
-            .map(|&(ref key, ref val)| {
+            .map(|(key, val)| {
                 (
                     Cow::Owned(key.borrow().to_string()),
                     Cow::Owned(val.borrow().to_string()),
@@ -259,7 +259,7 @@ unsafe impl UniqueValue for str {
 
 unsafe impl UniqueValue for String {
     fn get_unique(&self) -> Option<&str> {
-        Some(&self)
+        Some(self)
     }
 }
 
@@ -289,7 +289,7 @@ unsafe impl<V: UniqueValue> UniqueValue for [V] {
         if self.len() > 1 {
             None
         } else {
-            self.get(0).and_then(V::get_unique)
+            self.first().and_then(V::get_unique)
         }
     }
 }
@@ -317,7 +317,7 @@ unsafe impl<V: UniqueValue> UniqueValue for Vec<V> {
         if self.len() > 1 {
             None
         } else {
-            self.get(0).and_then(V::get_unique)
+            self.first().and_then(V::get_unique)
         }
     }
 }

--- a/oxide-auth/src/endpoint/tests/access_token.rs
+++ b/oxide-auth/src/endpoint/tests/access_token.rs
@@ -48,7 +48,7 @@ impl AccessTokenSetup {
         registrar.register_client(client);
 
         let basic_authorization =
-            base64::encode(&format!("{}:{}", EXAMPLE_CLIENT_ID, EXAMPLE_PASSPHRASE));
+            base64::encode(format!("{}:{}", EXAMPLE_CLIENT_ID, EXAMPLE_PASSPHRASE));
 
         AccessTokenSetup {
             registrar,
@@ -83,7 +83,7 @@ impl AccessTokenSetup {
         registrar.register_client(client);
 
         let basic_authorization =
-            base64::encode(&format!("{}:{}", EXAMPLE_CLIENT_ID, EXAMPLE_PASSPHRASE));
+            base64::encode(format!("{}:{}", EXAMPLE_CLIENT_ID, EXAMPLE_PASSPHRASE));
 
         AccessTokenSetup {
             registrar,
@@ -145,7 +145,7 @@ fn access_valid_public() {
     let valid_public = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "authorization_code"),
                 ("client_id", EXAMPLE_CLIENT_ID),
                 ("code", &setup.authtoken),
@@ -167,7 +167,7 @@ fn access_valid_private() {
     let valid_public = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "authorization_code"),
                 ("code", &setup.authtoken),
                 ("redirect_uri", EXAMPLE_REDIRECT_URI),
@@ -188,7 +188,7 @@ fn regression_case_insensitive_basic() {
     let valid_public = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "authorization_code"),
                 ("code", &setup.authtoken),
                 ("redirect_uri", EXAMPLE_REDIRECT_URI),
@@ -238,7 +238,7 @@ fn access_equivalent_url() {
     setup.test_success(CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "authorization_code"),
                 ("client_id", CLIENT_ID),
                 ("code", &authtoken),
@@ -254,7 +254,7 @@ fn access_equivalent_url() {
     setup.test_success(CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "authorization_code"),
                 ("client_id", CLIENT_ID),
                 ("code", &authtoken),
@@ -274,7 +274,7 @@ fn access_request_unknown_client() {
     let unknown_client = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "authorization_code"),
                 ("code", &setup.authtoken),
                 ("redirect_uri", EXAMPLE_REDIRECT_URI),
@@ -284,7 +284,7 @@ fn access_request_unknown_client() {
         ),
         auth: Some(
             "Basic ".to_string()
-                + &base64::encode(&format!("{}:{}", "SomeOtherClient", EXAMPLE_PASSPHRASE)),
+                + &base64::encode(format!("{}:{}", "SomeOtherClient", EXAMPLE_PASSPHRASE)),
         ),
     };
 
@@ -298,7 +298,7 @@ fn access_request_wrong_authentication() {
     let wrong_authentication = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "authorization_code"),
                 ("code", &setup.authtoken),
                 ("redirect_uri", EXAMPLE_REDIRECT_URI),
@@ -319,7 +319,7 @@ fn access_request_wrong_password() {
     let wrong_password = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "authorization_code"),
                 ("code", &setup.authtoken),
                 ("redirect_uri", EXAMPLE_REDIRECT_URI),
@@ -329,7 +329,7 @@ fn access_request_wrong_password() {
         ),
         auth: Some(
             "Basic ".to_string()
-                + &base64::encode(&format!("{}:{}", EXAMPLE_CLIENT_ID, "NotTheRightPassphrase")),
+                + &base64::encode(format!("{}:{}", EXAMPLE_CLIENT_ID, "NotTheRightPassphrase")),
         ),
     };
 
@@ -343,7 +343,7 @@ fn access_request_empty_password() {
     let empty_password = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "authorization_code"),
                 ("code", &setup.authtoken),
                 ("redirect_uri", EXAMPLE_REDIRECT_URI),
@@ -351,7 +351,7 @@ fn access_request_empty_password() {
             .iter()
             .to_single_value_query(),
         ),
-        auth: Some("Basic ".to_string() + &base64::encode(&format!("{}:{}", EXAMPLE_CLIENT_ID, ""))),
+        auth: Some("Basic ".to_string() + &base64::encode(format!("{}:{}", EXAMPLE_CLIENT_ID, ""))),
     };
 
     setup.test_simple_error(empty_password);
@@ -364,7 +364,7 @@ fn access_request_multiple_client_indications() {
     let multiple_client_indications = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "authorization_code"),
                 ("client_id", EXAMPLE_CLIENT_ID),
                 ("code", &setup.authtoken),
@@ -386,7 +386,7 @@ fn access_request_public_authorization() {
     let public_authorization = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "authorization_code"),
                 ("code", &setup.authtoken),
                 ("redirect_uri", EXAMPLE_REDIRECT_URI),
@@ -407,7 +407,7 @@ fn access_request_public_missing_client() {
     let public_missing_client = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "authorization_code"),
                 ("code", &setup.authtoken),
                 ("redirect_uri", EXAMPLE_REDIRECT_URI),
@@ -428,7 +428,7 @@ fn access_request_invalid_basic() {
     let invalid_basic = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "authorization_code"),
                 ("code", &setup.authtoken),
                 ("redirect_uri", EXAMPLE_REDIRECT_URI),
@@ -449,7 +449,7 @@ fn access_request_wrong_redirection() {
     let wrong_redirection = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "authorization_code"),
                 ("code", &setup.authtoken),
                 ("redirect_uri", "https://wrong.client.example/endpoint"),
@@ -470,7 +470,7 @@ fn access_request_invalid_redirection() {
     let invalid_redirection = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "authorization_code"),
                 ("code", &setup.authtoken),
                 ("redirect_uri", "\\://"),
@@ -491,7 +491,7 @@ fn access_request_no_code() {
     let no_code = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "authorization_code"),
                 ("redirect_uri", EXAMPLE_REDIRECT_URI),
             ]
@@ -507,7 +507,7 @@ fn access_request_no_code() {
 #[test]
 fn access_request_multiple_codes() {
     let mut setup = AccessTokenSetup::private_client();
-    let mut urlbody = vec![
+    let mut urlbody = [
         ("grant_type", "authorization_code"),
         ("code", &setup.authtoken),
         ("redirect_uri", EXAMPLE_REDIRECT_URI),
@@ -535,7 +535,7 @@ fn access_request_wrong_grant_type() {
     let wrong_grant_type = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "another_grant_type"),
                 ("code", &setup.authtoken),
                 ("redirect_uri", EXAMPLE_REDIRECT_URI),
@@ -556,7 +556,7 @@ fn private_in_body() {
     let valid_public = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "authorization_code"),
                 ("code", &setup.authtoken),
                 ("redirect_uri", EXAMPLE_REDIRECT_URI),
@@ -579,7 +579,7 @@ fn unwanted_private_in_body_fails() {
     let valid_public = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "authorization_code"),
                 ("code", &setup.authtoken),
                 ("redirect_uri", EXAMPLE_REDIRECT_URI),
@@ -603,7 +603,7 @@ fn private_duplicate_authentication() {
     let valid_public = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "authorization_code"),
                 ("code", &setup.authtoken),
                 ("redirect_uri", EXAMPLE_REDIRECT_URI),

--- a/oxide-auth/src/endpoint/tests/authorization.rs
+++ b/oxide-auth/src/endpoint/tests/authorization.rs
@@ -46,7 +46,7 @@ impl AuthorizationSetup {
         assert_eq!(response.status, Status::Redirect);
 
         match response.location {
-            Some(ref url) if url.as_str().contains("error") => (),
+            Some(ref url) if !url.as_str().contains("error") => (),
             other => panic!("Expected successful redirect: {:?}", other),
         }
     }

--- a/oxide-auth/src/endpoint/tests/authorization.rs
+++ b/oxide-auth/src/endpoint/tests/authorization.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use crate::primitives::authorizer::AuthMap;
 use crate::primitives::registrar::{Client, ClientMap, RegisteredUrl};
 
-use crate::endpoint::{OwnerSolicitor};
+use crate::endpoint::OwnerSolicitor;
 
 use crate::frontends::simple::endpoint::authorization_flow;
 
@@ -36,7 +36,7 @@ impl AuthorizationSetup {
 
     fn test_success(&mut self, request: CraftedRequest) {
         let response = authorization_flow(
-            &mut self.registrar,
+            &self.registrar,
             &mut self.authorizer,
             &mut Allow(EXAMPLE_OWNER_ID.to_string()),
         )
@@ -46,14 +46,14 @@ impl AuthorizationSetup {
         assert_eq!(response.status, Status::Redirect);
 
         match response.location {
-            Some(ref url) if url.as_str().find("error").is_none() => (),
+            Some(ref url) if url.as_str().contains("error") => (),
             other => panic!("Expected successful redirect: {:?}", other),
         }
     }
 
     fn test_silent_error(&mut self, request: CraftedRequest) {
         match authorization_flow(
-            &mut self.registrar,
+            &self.registrar,
             &mut self.authorizer,
             &mut Allow(EXAMPLE_OWNER_ID.to_string()),
         )
@@ -69,8 +69,8 @@ impl AuthorizationSetup {
     where
         P: OwnerSolicitor<CraftedRequest>,
     {
-        let response = authorization_flow(&mut self.registrar, &mut self.authorizer, &mut pagehandler)
-            .execute(request);
+        let response =
+            authorization_flow(&self.registrar, &mut self.authorizer, &mut pagehandler).execute(request);
 
         let response = match response {
             Err(resp) => panic!("Expected redirect with error set: {:?}", resp),
@@ -83,10 +83,7 @@ impl AuthorizationSetup {
                     .query_pairs()
                     .collect::<HashMap<_, _>>()
                     .get("error")
-                    .is_some() =>
-            {
-                ()
-            }
+                    .is_some() => {}
             other => panic!("Expected location with error set description: {:?}", other),
         }
     }
@@ -96,7 +93,7 @@ impl AuthorizationSetup {
 fn auth_success() {
     let success = CraftedRequest {
         query: Some(
-            vec![
+            [
                 ("response_type", "code"),
                 ("client_id", EXAMPLE_CLIENT_ID),
                 ("redirect_uri", EXAMPLE_REDIRECT_URI),
@@ -114,7 +111,7 @@ fn auth_success() {
 #[test]
 fn auth_request_silent_missing_client() {
     let missing_client = CraftedRequest {
-        query: Some(vec![("response_type", "code")].iter().to_single_value_query()),
+        query: Some([("response_type", "code")].iter().to_single_value_query()),
         urlbody: None,
         auth: None,
     };
@@ -127,7 +124,7 @@ fn auth_request_silent_unknown_client() {
     // The client_id is not registered
     let unknown_client = CraftedRequest {
         query: Some(
-            vec![
+            [
                 ("response_type", "code"),
                 ("client_id", "SomeOtherClient"),
                 ("redirect_uri", "https://wrong.client.example/endpoint"),
@@ -147,7 +144,7 @@ fn auth_request_silent_mismatching_redirect() {
     // The redirect_uri does not match
     let mismatching_redirect = CraftedRequest {
         query: Some(
-            vec![
+            [
                 ("response_type", "code"),
                 ("client_id", EXAMPLE_CLIENT_ID),
                 ("redirect_uri", "https://wrong.client.example/endpoint"),
@@ -166,9 +163,9 @@ fn auth_request_silent_mismatching_redirect() {
 fn auth_request_silent_mismatching_literal_redirect() {
     // The redirect_uri does not match if stringly matched.
     let mut setup = AuthorizationSetup::new();
-    const UNIQUE_CLIENT: &'static str = "client_auth_request_silent_mismatching_literal_redirect";
-    const REGISTERED_URL: &'static str = "https://right.client.example/endpoint";
-    const TRIED_URL: &'static str = "https://right.client.example/endpoint/";
+    const UNIQUE_CLIENT: &str = "client_auth_request_silent_mismatching_literal_redirect";
+    const REGISTERED_URL: &str = "https://right.client.example/endpoint";
+    const TRIED_URL: &str = "https://right.client.example/endpoint/";
 
     let client = Client::confidential(
         UNIQUE_CLIENT,
@@ -180,7 +177,7 @@ fn auth_request_silent_mismatching_literal_redirect() {
 
     let mismatching_redirect = CraftedRequest {
         query: Some(
-            vec![
+            [
                 ("response_type", "code"),
                 ("client_id", UNIQUE_CLIENT),
                 ("redirect_uri", TRIED_URL),
@@ -196,7 +193,7 @@ fn auth_request_silent_mismatching_literal_redirect() {
 
     let valid_redirect = CraftedRequest {
         query: Some(
-            vec![
+            [
                 ("response_type", "code"),
                 ("client_id", UNIQUE_CLIENT),
                 ("redirect_uri", REGISTERED_URL),
@@ -216,7 +213,7 @@ fn auth_request_silent_invalid_redirect() {
     // The redirect_uri is not an uri ('\' is not allowed to appear in the scheme)
     let invalid_redirect = CraftedRequest {
         query: Some(
-            vec![
+            [
                 ("response_type", "code"),
                 ("client_id", EXAMPLE_CLIENT_ID),
                 ("redirect_uri", "\\://"),
@@ -236,7 +233,7 @@ fn auth_request_error_denied() {
     // Used in conjunction with a denying authorization handler below
     let denied_request = CraftedRequest {
         query: Some(
-            vec![
+            [
                 ("response_type", "code"),
                 ("client_id", EXAMPLE_CLIENT_ID),
                 ("redirect_uri", EXAMPLE_REDIRECT_URI),
@@ -256,7 +253,7 @@ fn auth_request_error_unsupported_method() {
     // Requesting an authorization token for a method other than code
     let unsupported_method = CraftedRequest {
         query: Some(
-            vec![
+            [
                 ("response_type", "other_method"),
                 ("client_id", EXAMPLE_CLIENT_ID),
                 ("redirect_uri", EXAMPLE_REDIRECT_URI),
@@ -277,7 +274,7 @@ fn auth_request_error_malformed_scope() {
     // A scope with malformed formatting
     let malformed_scope = CraftedRequest {
         query: Some(
-            vec![
+            [
                 ("response_type", "code"),
                 ("client_id", EXAMPLE_CLIENT_ID),
                 ("redirect_uri", EXAMPLE_REDIRECT_URI),

--- a/oxide-auth/src/endpoint/tests/client_credentials.rs
+++ b/oxide-auth/src/endpoint/tests/client_credentials.rs
@@ -1,7 +1,7 @@
 use crate::primitives::registrar::{Client, ClientMap, RegisteredUrl};
 use crate::primitives::issuer::TokenMap;
 
-use crate::endpoint::{OwnerSolicitor};
+use crate::endpoint::OwnerSolicitor;
 
 use crate::frontends::simple::endpoint::client_credentials_flow;
 
@@ -29,7 +29,7 @@ impl ClientCredentialsSetup {
         );
         registrar.register_client(client);
         let basic_authorization =
-            base64::encode(&format!("{}:{}", EXAMPLE_CLIENT_ID, EXAMPLE_PASSPHRASE));
+            base64::encode(format!("{}:{}", EXAMPLE_CLIENT_ID, EXAMPLE_PASSPHRASE));
         ClientCredentialsSetup {
             registrar,
             issuer,
@@ -49,7 +49,7 @@ impl ClientCredentialsSetup {
         );
         registrar.register_client(client);
         let basic_authorization =
-            base64::encode(&format!("{}:{}", EXAMPLE_CLIENT_ID, EXAMPLE_PASSPHRASE));
+            base64::encode(format!("{}:{}", EXAMPLE_CLIENT_ID, EXAMPLE_PASSPHRASE));
         ClientCredentialsSetup {
             registrar,
             issuer,
@@ -62,7 +62,7 @@ impl ClientCredentialsSetup {
     where
         S: OwnerSolicitor<CraftedRequest>,
     {
-        let mut flow = client_credentials_flow(&mut self.registrar, &mut self.issuer, &mut solicitor);
+        let mut flow = client_credentials_flow(&self.registrar, &mut self.issuer, &mut solicitor);
         flow.allow_credentials_in_body(self.allow_credentials_in_body);
         let response = flow.execute(request).expect("Expected non-error reponse");
 
@@ -73,7 +73,7 @@ impl ClientCredentialsSetup {
     where
         S: OwnerSolicitor<CraftedRequest>,
     {
-        let mut flow = client_credentials_flow(&mut self.registrar, &mut self.issuer, &mut solicitor);
+        let mut flow = client_credentials_flow(&self.registrar, &mut self.issuer, &mut solicitor);
         flow.allow_credentials_in_body(self.allow_credentials_in_body);
         let response = flow.execute(request).expect("Expected non-error response");
 
@@ -84,7 +84,7 @@ impl ClientCredentialsSetup {
     where
         S: OwnerSolicitor<CraftedRequest>,
     {
-        let mut flow = client_credentials_flow(&mut self.registrar, &mut self.issuer, &mut solicitor);
+        let mut flow = client_credentials_flow(&self.registrar, &mut self.issuer, &mut solicitor);
         flow.allow_credentials_in_body(self.allow_credentials_in_body);
         let response = flow.execute(request).expect("Expected non-error response");
 
@@ -98,7 +98,7 @@ fn client_credentials_success() {
     let success = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![("grant_type", "client_credentials")]
+            [("grant_type", "client_credentials")]
                 .iter()
                 .to_single_value_query(),
         ),
@@ -114,7 +114,7 @@ fn client_credentials_success_changed_owner() {
     let success = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![("grant_type", "client_credentials")]
+            [("grant_type", "client_credentials")]
                 .iter()
                 .to_single_value_query(),
         ),
@@ -130,7 +130,7 @@ fn client_credentials_deny_public_client() {
     let public_client = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "client_credentials"),
                 ("client_id", EXAMPLE_CLIENT_ID),
             ]
@@ -146,11 +146,11 @@ fn client_credentials_deny_public_client() {
 #[test]
 fn client_credentials_deny_incorrect_credentials() {
     let mut setup = ClientCredentialsSetup::new();
-    let basic_authorization = base64::encode(&format!("{}:the wrong passphrase", EXAMPLE_CLIENT_ID));
+    let basic_authorization = base64::encode(format!("{}:the wrong passphrase", EXAMPLE_CLIENT_ID));
     let wrong_credentials = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![("grant_type", "client_credentials")]
+            [("grant_type", "client_credentials")]
                 .iter()
                 .to_single_value_query(),
         ),
@@ -166,7 +166,7 @@ fn client_credentials_deny_missing_credentials() {
     let missing_credentials = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "client_credentials"),
                 ("client_id", EXAMPLE_CLIENT_ID),
             ]
@@ -185,7 +185,7 @@ fn client_credentials_deny_unknown_client_missing_password() {
     let unknown_client = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "client_credentials"),
                 ("client_id", "SomeOtherClient"),
             ]
@@ -206,7 +206,7 @@ fn client_credentials_deny_body_missing_password() {
     let unknown_client = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "client_credentials"),
                 ("client_id", EXAMPLE_CLIENT_ID),
             ]
@@ -223,11 +223,11 @@ fn client_credentials_deny_body_missing_password() {
 fn client_credentials_deny_unknown_client() {
     // The client_id is not registered
     let mut setup = ClientCredentialsSetup::new();
-    let basic_authorization = base64::encode(&format!("{}:{}", "SomeOtherClient", EXAMPLE_PASSPHRASE));
+    let basic_authorization = base64::encode(format!("{}:{}", "SomeOtherClient", EXAMPLE_PASSPHRASE));
     let unknown_client = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![("grant_type", "client_credentials")]
+            [("grant_type", "client_credentials")]
                 .iter()
                 .to_single_value_query(),
         ),
@@ -245,7 +245,7 @@ fn client_credentials_deny_body_unknown_client() {
     let unknown_client = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "client_credentials"),
                 ("client_id", "SomeOtherClient"),
                 ("client_secret", EXAMPLE_PASSPHRASE),
@@ -269,7 +269,7 @@ fn client_body_credentials() {
     let unknown_client = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "client_credentials"),
                 ("client_id", EXAMPLE_CLIENT_ID),
                 ("client_secret", EXAMPLE_PASSPHRASE),
@@ -292,7 +292,7 @@ fn client_duplicate_credentials_denied() {
     let unknown_client = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "client_credentials"),
                 ("client_id", EXAMPLE_CLIENT_ID),
                 ("client_secret", EXAMPLE_PASSPHRASE),
@@ -313,7 +313,7 @@ fn client_credentials_request_error_denied() {
     let denied_request = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![("grant_type", "client_credentials")]
+            [("grant_type", "client_credentials")]
                 .iter()
                 .to_single_value_query(),
         ),
@@ -330,7 +330,7 @@ fn client_credentials_request_error_unsupported_grant_type() {
     let unsupported_grant_type = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![("grant_type", "not_client_credentials")]
+            [("grant_type", "not_client_credentials")]
                 .iter()
                 .to_single_value_query(),
         ),
@@ -347,7 +347,7 @@ fn client_credentials_request_error_malformed_scope() {
     let malformed_scope = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "client_credentials"),
                 ("scope", "\"no quotes (0x22) allowed\""),
             ]

--- a/oxide-auth/src/endpoint/tests/mod.rs
+++ b/oxide-auth/src/endpoint/tests/mod.rs
@@ -41,9 +41,10 @@ struct CraftedResponse {
 }
 
 /// An enum containing the necessary HTTP status codes.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Hash)]
 enum Status {
     /// Http status code 200.
+    #[default]
     Ok,
 
     /// Http status code 302.
@@ -197,14 +198,8 @@ where
     V: AsRef<str> + 'r,
 {
     fn to_single_value_query(self) -> HashMap<String, Vec<String>> {
-        self.map(|&(ref k, ref v)| (k.as_ref().to_string(), vec![v.as_ref().to_string()]))
+        self.map(|(k, v)| (k.as_ref().to_string(), vec![v.as_ref().to_string()]))
             .collect()
-    }
-}
-
-impl Default for Status {
-    fn default() -> Self {
-        Status::Ok
     }
 }
 

--- a/oxide-auth/src/endpoint/tests/pkce.rs
+++ b/oxide-auth/src/endpoint/tests/pkce.rs
@@ -125,7 +125,7 @@ impl PkceSetup {
 
     fn assert_nonerror_redirect(response: CraftedResponse) {
         assert_eq!(response.status, Status::Redirect, "Expected redirect to client");
-        assert!(response.location.unwrap().as_str().contains("error"));
+        assert!(!response.location.unwrap().as_str().contains("error"));
     }
 
     fn json_response(body: Option<Body>) -> TokenResponse {

--- a/oxide-auth/src/endpoint/tests/pkce.rs
+++ b/oxide-auth/src/endpoint/tests/pkce.rs
@@ -38,9 +38,9 @@ impl PkceSetup {
         let issuer = TokenMap::new(RandomGenerator::new(16));
 
         PkceSetup {
-            registrar: registrar,
-            authorizer: authorizer,
-            issuer: issuer,
+            registrar,
+            authorizer,
+            issuer,
             auth_token: token,
             // The following are from https://tools.ietf.org/html/rfc7636#page-18
             sha256_challenge: "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM".to_string(),
@@ -125,7 +125,7 @@ impl PkceSetup {
 
     fn assert_nonerror_redirect(response: CraftedResponse) {
         assert_eq!(response.status, Status::Redirect, "Expected redirect to client");
-        assert!(response.location.unwrap().as_str().find("error").is_none());
+        assert!(response.location.unwrap().as_str().contains("error"));
     }
 
     fn json_response(body: Option<Body>) -> TokenResponse {
@@ -144,7 +144,7 @@ fn pkce_correct_verifier() {
 
     let correct_authorization = CraftedRequest {
         query: Some(
-            vec![
+            [
                 ("client_id", EXAMPLE_CLIENT_ID),
                 ("redirect_uri", EXAMPLE_REDIRECT_URI),
                 ("response_type", "code"),
@@ -161,7 +161,7 @@ fn pkce_correct_verifier() {
     let correct_access = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "authorization_code"),
                 ("client_id", EXAMPLE_CLIENT_ID),
                 ("code", &setup.auth_token),
@@ -183,7 +183,7 @@ fn pkce_failed_verifier() {
 
     let correct_authorization = CraftedRequest {
         query: Some(
-            vec![
+            [
                 ("client_id", EXAMPLE_CLIENT_ID),
                 ("redirect_uri", EXAMPLE_REDIRECT_URI),
                 ("response_type", "code"),
@@ -200,7 +200,7 @@ fn pkce_failed_verifier() {
     let correct_access = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "authorization_code"),
                 ("client_id", EXAMPLE_CLIENT_ID),
                 ("code", &setup.auth_token),

--- a/oxide-auth/src/endpoint/tests/refresh.rs
+++ b/oxide-auth/src/endpoint/tests/refresh.rs
@@ -53,7 +53,7 @@ impl RefreshTokenSetup {
         let refresh_token = issued.refresh.clone().unwrap();
 
         let basic_authorization =
-            base64::encode(&format!("{}:{}", EXAMPLE_CLIENT_ID, EXAMPLE_PASSPHRASE));
+            base64::encode(format!("{}:{}", EXAMPLE_CLIENT_ID, EXAMPLE_PASSPHRASE));
         let basic_authorization = format!("Basic {}", basic_authorization);
 
         RefreshTokenSetup {
@@ -208,7 +208,7 @@ fn access_valid_public() {
     let valid_public = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "refresh_token"),
                 ("refresh_token", &setup.refresh_token),
             ]
@@ -229,7 +229,7 @@ fn access_valid_private() {
     let valid_private = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "refresh_token"),
                 ("refresh_token", &setup.refresh_token),
             ]
@@ -247,20 +247,20 @@ fn access_valid_private() {
 fn public_private_invalid_grant() {
     let mut setup = RefreshTokenSetup::public_client();
     let client = Client::confidential(
-        "PrivateClient".into(),
+        "PrivateClient",
         RegisteredUrl::Semantic(EXAMPLE_REDIRECT_URI.parse().unwrap()),
         EXAMPLE_SCOPE.parse().unwrap(),
         EXAMPLE_PASSPHRASE.as_bytes(),
     );
     setup.registrar.register_client(client);
 
-    let basic_authorization = base64::encode(&format!("{}:{}", "PrivateClient", EXAMPLE_PASSPHRASE));
+    let basic_authorization = base64::encode(format!("{}:{}", "PrivateClient", EXAMPLE_PASSPHRASE));
     let basic_authorization = format!("Basic {}", basic_authorization);
 
     let authenticated = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "refresh_token"),
                 ("refresh_token", &setup.refresh_token),
             ]
@@ -280,7 +280,7 @@ fn private_wrong_client_fails() {
     let valid_public = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "refresh_token"),
                 ("refresh_token", &setup.refresh_token),
             ]
@@ -295,7 +295,7 @@ fn private_wrong_client_fails() {
     let wrong_authentication = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "refresh_token"),
                 ("refresh_token", &setup.refresh_token),
             ]
@@ -315,7 +315,7 @@ fn invalid_request() {
     let bad_base64 = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "refresh_token"),
                 ("refresh_token", &setup.refresh_token),
             ]
@@ -329,11 +329,7 @@ fn invalid_request() {
 
     let no_token = CraftedRequest {
         query: None,
-        urlbody: Some(
-            vec![("grant_type", "refresh_token")]
-                .iter()
-                .to_single_value_query(),
-        ),
+        urlbody: Some([("grant_type", "refresh_token")].iter().to_single_value_query()),
         auth: Some(setup.basic_authorization.clone()),
     };
 
@@ -348,7 +344,7 @@ fn regression_case_insensitive_basic() {
     let case_changed_authorization = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "refresh_token"),
                 ("refresh_token", &setup.refresh_token),
             ]
@@ -370,7 +366,7 @@ fn public_invalid_token() {
     let valid_public = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "refresh_token"),
                 ("refresh_token", WRONG_REFRESH_TOKEN),
             ]
@@ -392,7 +388,7 @@ fn private_invalid_token() {
     let valid_private = CraftedRequest {
         query: None,
         urlbody: Some(
-            vec![
+            [
                 ("grant_type", "refresh_token"),
                 ("refresh_token", WRONG_REFRESH_TOKEN),
             ]

--- a/oxide-auth/src/endpoint/tests/resource.rs
+++ b/oxide-auth/src/endpoint/tests/resource.rs
@@ -75,9 +75,8 @@ impl ResourceSetup {
     }
 
     fn test_access_error(&mut self, request: CraftedRequest) {
-        match resource_flow(&mut self.issuer, &self.resource_scope).execute(request) {
-            Ok(resp) => panic!("Expected an error instead of {:?}", resp),
-            Err(_) => (),
+        if let Ok(resp) = resource_flow(&mut self.issuer, &self.resource_scope).execute(request) {
+            panic!("Expected an error instead of {:?}", resp)
         }
     }
 }

--- a/oxide-auth/src/frontends/simple/request.rs
+++ b/oxide-auth/src/frontends/simple/request.rs
@@ -42,9 +42,10 @@ pub struct Response {
 }
 
 /// An enum containing the necessary HTTP status codes.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Hash)]
 pub enum Status {
     /// Http status code 200.
+    #[default]
     Ok,
 
     /// Http status code 302.
@@ -184,12 +185,6 @@ impl NoError {
     /// Since `NoError` is uninhabited, this always works but is never executed.
     pub fn into<T>(self) -> T {
         match self {}
-    }
-}
-
-impl Default for Status {
-    fn default() -> Self {
-        Status::Ok
     }
 }
 

--- a/oxide-auth/src/primitives/authorizer.rs
+++ b/oxide-auth/src/primitives/authorizer.rs
@@ -104,7 +104,7 @@ impl<I: TagGrant> Authorizer for AuthMap<I> {
         Ok(token)
     }
 
-    fn extract<'a>(&mut self, grant: &'a str) -> Result<Option<Grant>, ()> {
+    fn extract(&mut self, grant: &str) -> Result<Option<Grant>, ()> {
         Ok(self.tokens.remove(grant))
     }
 }

--- a/oxide-auth/src/primitives/grant.rs
+++ b/oxide-auth/src/primitives/grant.rs
@@ -93,7 +93,7 @@ impl Value {
     /// but consists only of the key, and `Some(_)` otherwise.
     pub fn public_value(&self) -> Result<Option<&str>, ()> {
         match self {
-            Value::Public(Some(content)) => Ok(Some(&content)),
+            Value::Public(Some(content)) => Ok(Some(content)),
             Value::Public(None) => Ok(None),
             _ => Err(()),
         }
@@ -116,7 +116,7 @@ impl Value {
     /// but consists only of the key, and `Some(_)` otherwise.
     pub fn private_value(&self) -> Result<Option<&str>, ()> {
         match self {
-            Value::Private(Some(content)) => Ok(Some(&content)),
+            Value::Private(Some(content)) => Ok(Some(content)),
             Value::Private(None) => Ok(None),
             _ => Err(()),
         }
@@ -266,7 +266,7 @@ mod tests {
         assert_eq!(
             extensions
                 .public()
-                .filter(|&(name, value)| name == "pub_none" && value == None)
+                .filter(|&(name, value)| name == "pub_none" && value.is_none())
                 .count(),
             1
         );
@@ -282,7 +282,7 @@ mod tests {
         assert_eq!(
             extensions
                 .private()
-                .filter(|&(name, value)| name == "priv_none" && value == None)
+                .filter(|&(name, value)| name == "priv_none" && value.is_none())
                 .count(),
             1
         );

--- a/oxide-auth/src/primitives/issuer.rs
+++ b/oxide-auth/src/primitives/issuer.rs
@@ -254,11 +254,11 @@ impl<G: TagGrant> Issuer for TokenMap<G> {
             let access = self.generator.tag(self.usage, &grant)?;
             let refresh = self.generator.tag(self.usage.wrapping_add(1), &grant)?;
             debug_assert!(
-                access.len() > 0,
+                !access.is_empty(),
                 "An empty access token was generated, this is horribly insecure."
             );
             debug_assert!(
-                refresh.len() > 0,
+                !refresh.is_empty(),
                 "An empty refresh token was generated, this is horribly insecure."
             );
             (access, refresh)
@@ -523,11 +523,11 @@ impl Issuer for TokenSigner {
     }
 
     fn recover_token<'a>(&'a self, token: &'a str) -> Result<Option<Grant>, ()> {
-        (&&*self).recover_token(token)
+        (&self).recover_token(token)
     }
 
     fn recover_refresh<'a>(&'a self, token: &'a str) -> Result<Option<Grant>, ()> {
-        (&&*self).recover_refresh(token)
+        (&self).recover_refresh(token)
     }
 }
 

--- a/oxide-auth/src/primitives/registrar.rs
+++ b/oxide-auth/src/primitives/registrar.rs
@@ -101,7 +101,7 @@ impl<'de> Deserialize<'de> for ExactUrl {
         D: serde::Deserializer<'de>,
     {
         let string: &str = Deserialize::deserialize(deserializer)?;
-        core::str::FromStr::from_str(&string).map_err(serde::de::Error::custom)
+        core::str::FromStr::from_str(string).map_err(serde::de::Error::custom)
     }
 }
 
@@ -562,7 +562,7 @@ impl<'a> RegisteredClient<'a> {
     pub fn check_authentication(&self, passphrase: Option<&[u8]>) -> Result<(), RegistrarError> {
         match (passphrase, &self.client.encoded_client) {
             (None, &ClientType::Public) => Ok(()),
-            (Some(provided), &ClientType::Confidential { passdata: ref stored }) => {
+            (Some(provided), ClientType::Confidential { passdata: ref stored }) => {
                 self.policy.check(&self.client.client_id, provided, stored)
             }
             _ => Err(RegistrarError::Unspecified),
@@ -649,7 +649,7 @@ impl ClientMap {
     }
 
     // This is not an instance method because it needs to borrow the box but register needs &mut
-    fn current_policy<'a>(policy: &'a Option<Box<dyn PasswordPolicy>>) -> &'a dyn PasswordPolicy {
+    fn current_policy(policy: &Option<Box<dyn PasswordPolicy>>) -> &dyn PasswordPolicy {
         policy
             .as_ref()
             .map(|boxed| &**boxed)
@@ -862,8 +862,7 @@ mod tests {
                 .expect("Authorization of public client has changed");
             registrar
                 .check(public_id, Some(b""))
-                .err()
-                .expect("Authorization with password succeeded");
+                .expect_err("Authorization with password succeeded");
         }
 
         let private_client = Client::confidential(
@@ -881,8 +880,7 @@ mod tests {
                 .expect("Authorization with right password did not succeed");
             registrar
                 .check(private_id, Some(b"Not the private passphrase"))
-                .err()
-                .expect("Authorization succeed with wrong password");
+                .expect_err("Authorization succeed with wrong password");
         }
     }
 

--- a/oxide-auth/src/primitives/scope.rs
+++ b/oxide-auth/src/primitives/scope.rs
@@ -72,8 +72,8 @@ impl Scope {
     fn invalid_scope_char(ch: char) -> bool {
         match ch {
             '\x21' => false,
-            ch if ch >= '\x23' && ch <= '\x5b' => false,
-            ch if ch >= '\x5d' && ch <= '\x7e' => false,
+            ch if ('\x23'..='\x5b').contains(&ch) => false,
+            ch if ('\x5d'..='\x7e').contains(&ch) => false,
             ' ' => false, // Space seperator is a valid char
             _ => true,
         }


### PR DESCRIPTION
This PR has no real public changes, more of a generic fixing of clippy lints.  
I just noticed a bunch of warnings since my RA install runs `cargo clippy` instead of `cargo check`.

Thought it might be a few nice fixes, especially reducing the complexity of some function signatures by removing unnecessary explicit lifetimes.

 - [x] I have read the [contribution guidelines][Contributing]

I license past and future contributions under the dual MIT/Apache-2.0 license, allowing licensees to chose either at their option.

[Contributing]: CONTRIBUTING.md
