### PR TITLE
adjust OAuthResource to support usage

### DIFF
--- a/oxide-auth-axum/src/request.rs
+++ b/oxide-auth-axum/src/request.rs
@@ -133,3 +133,10 @@ where
         Ok(Self { auth })
     }
 }
+
+impl OAuthResource {
+    /// Fetch the authorization header from the request
+    pub fn authorization_header(&self) -> Option<&str> {
+        self.auth.as_deref()
+    }
+}


### PR DESCRIPTION
This fixes #185 .

There are no examples for `oxide-auth-axum` (:shrug:) but it would appear that [`OAuthResource`](https://github.com/HeroicKatora/oxide-auth/blob/master/oxide-auth-axum/src/request.rs#L25) is a dead type. 

I license past and future contributions under the dual MIT/Apache-2.0 license, allowing licensees to chose either at their option.
