### PR TITLE
fix: Allow a client to specify the client_id in body when using Authenticate

### DIFF
--- a/oxide-auth/src/code_grant/accesstoken.rs
+++ b/oxide-auth/src/code_grant/accesstoken.rs
@@ -333,9 +333,7 @@ impl AccessToken {
         let mut credentials = Credentials::None;
         if let Some((client_id, auth)) = &authorization {
             credentials.authenticate(client_id.as_ref(), auth.as_ref());
-        }
-
-        if let Some(client_id) = &client_id {
+        } else if let Some(client_id) = &client_id {
             match &client_secret {
                 Some(auth) if request.allow_credentials_in_body() => {
                     credentials.authenticate(client_id.as_ref(), auth.as_ref().as_bytes())


### PR DESCRIPTION
Currently when a client uses Basic Auth but still specifies `client_id` as a body parameter, this library will raise an `invalid_request` error. However specifying `client_id` is completely acceptable to the standard, even when using Basic Auth. In fact, some client libraries, like for example the elixir oauth2 library always set the client_id parameter.

This Commit makes it so we ignore any credentials specified in the body, if Basic Auth is used

This changes/fixes/improves &#8230;

 - [ ] I have read the [contribution guidelines][Contributing] - do not exist
 - [ ] This change has tests (remove for doc only) - AuthCode seems to not have any test coverage, the test suite also failes to compile on current rust
 - [x] This change has documentation - not needed, bugfix
 - [x] Corresponds to issue (number) - none

I license this contribution under the dual MIT/Apache-2.0 license, allowing licensees to chose either at their option.


