### PR TITLE
feat: implement Extension also for &mut AddonList

### DIFF
--- a/oxide-auth-async/src/frontends/simple/extensions/list.rs
+++ b/oxide-auth-async/src/frontends/simple/extensions/list.rs
@@ -1,12 +1,14 @@
 use async_trait::async_trait;
 use oxide_auth::code_grant::authorization::Request;
 use oxide_auth::code_grant::accesstoken::Request as TokenRequest;
+use oxide_auth::code_grant::client_credentials::Request as ClientCredentialsRequest;
 use oxide_auth::frontends::simple::extensions::{AddonList, AddonResult};
 use oxide_auth::primitives::grant::Extensions;
 
 use crate::endpoint::Extension;
 use crate::code_grant::access_token::{Extension as AccessTokenExtension};
 use crate::code_grant::authorization::Extension as AuthorizationExtension;
+use crate::code_grant::client_credentials::{Extension as ClientCredentialsExtension};
 
 impl Extension for AddonList {
     fn authorization(&mut self) -> Option<&mut (dyn AuthorizationExtension + Send)> {
@@ -14,6 +16,10 @@ impl Extension for AddonList {
     }
 
     fn access_token(&mut self) -> Option<&mut (dyn AccessTokenExtension + Send)> {
+        Some(self)
+    }
+
+    fn client_credentials(&mut self) -> Option<&mut (dyn ClientCredentialsExtension + Send)> {
         Some(self)
     }
 }
@@ -47,6 +53,27 @@ impl AccessTokenExtension for AddonList {
         for ext in self.access_token.iter() {
             let ext_data = data.remove(ext);
             let result = ext.execute(request, ext_data);
+
+            match result {
+                AddonResult::Ok => (),
+                AddonResult::Data(data) => result_data.set(ext, data),
+                AddonResult::Err => return Err(()),
+            }
+        }
+
+        Ok(result_data)
+    }
+}
+
+#[async_trait]
+impl ClientCredentialsExtension for AddonList {
+    async fn extend(
+        &mut self, request: &(dyn ClientCredentialsRequest + Sync),
+    ) -> std::result::Result<Extensions, ()> {
+        let mut result_data = Extensions::new();
+
+        for ext in self.client_credentials.iter() {
+            let result = ext.execute(request);
 
             match result {
                 AddonResult::Ok => (),

--- a/oxide-auth/src/frontends/simple/extensions/list.rs
+++ b/oxide-auth/src/frontends/simple/extensions/list.rs
@@ -75,6 +75,16 @@ impl Extension for AddonList {
     }
 }
 
+impl Extension for &mut AddonList {
+    fn authorization(&mut self) -> Option<&mut dyn AuthorizationExtension> {
+        Some(self)
+    }
+
+    fn access_token(&mut self) -> Option<&mut dyn AccessTokenExtension> {
+        Some(self)
+    }
+}
+
 impl AccessTokenExtension for AddonList {
     fn extend(
         &mut self, request: &dyn Request, mut data: Extensions,
@@ -96,6 +106,12 @@ impl AccessTokenExtension for AddonList {
     }
 }
 
+impl AccessTokenExtension for &mut AddonList {
+    fn extend(&mut self, request: &dyn Request, data: Extensions) -> Result<Extensions, ()> {
+        AccessTokenExtension::extend(*self, request, data)
+    }
+}
+
 impl AuthorizationExtension for AddonList {
     fn extend(&mut self, request: &dyn AuthRequest) -> Result<Extensions, ()> {
         let mut result_data = Extensions::new();
@@ -111,6 +127,12 @@ impl AuthorizationExtension for AddonList {
         }
 
         Ok(result_data)
+    }
+}
+
+impl AuthorizationExtension for &mut AddonList {
+    fn extend(&mut self, request: &dyn AuthRequest) -> Result<Extensions, ()> {
+        AuthorizationExtension::extend(*self, request)
     }
 }
 

--- a/oxide-auth/src/frontends/simple/extensions/list.rs
+++ b/oxide-auth/src/frontends/simple/extensions/list.rs
@@ -11,6 +11,7 @@ use crate::primitives::grant::{Extensions, GrantExtension};
 ///
 /// The owning representation of access extensions can be switched out to `Box<_>`, `Rc<_>` or
 /// other types.
+#[derive(Clone)]
 pub struct AddonList {
     /// Extension to be applied on authorize. This field is `pub` for `oxide-auth-async` be able to
     /// implement async version of some traits.

--- a/oxide-auth/src/frontends/simple/extensions/list.rs
+++ b/oxide-auth/src/frontends/simple/extensions/list.rs
@@ -7,7 +7,7 @@ use crate::code_grant::authorization::{Extension as AuthorizationExtension, Requ
 use crate::endpoint::Extension;
 use crate::primitives::grant::{Extensions, GrantExtension};
 
-/// A simple list of loosly related authorization and access addons.
+/// A simple list of loosely related authorization and access addons.
 ///
 /// The owning representation of access extensions can be switched out to `Box<_>`, `Rc<_>` or
 /// other types.

--- a/oxide-auth/src/frontends/simple/extensions/mod.rs
+++ b/oxide-auth/src/frontends/simple/extensions/mod.rs
@@ -3,6 +3,7 @@
 //! Note that extensions will probably return in `v0.4` but not its preview versions.
 pub use crate::code_grant::authorization::Request as AuthorizationRequest;
 pub use crate::code_grant::accesstoken::Request as AccessTokenRequest;
+pub use crate::code_grant::client_credentials::Request as ClientCredentialsRequest;
 
 mod extended;
 mod pkce;
@@ -53,6 +54,12 @@ pub trait AccessTokenAddon: GrantExtension {
     /// returned as a response to the authorization code request is provided as an additional
     /// parameter.
     fn execute(&self, request: &dyn AccessTokenRequest, code_data: Option<Value>) -> AddonResult;
+}
+
+/// An extension reacting to a client credentials request..
+pub trait ClientCredentialsAddon: GrantExtension {
+    /// Process a client credentials request, utilizing the extensions stored data if any.
+    fn execute(&self, request: &dyn ClientCredentialsRequest) -> AddonResult;
 }
 
 impl<'a, T: AuthorizationAddon + ?Sized> AuthorizationAddon for &'a T {
@@ -118,5 +125,38 @@ impl<T: AccessTokenAddon + ?Sized> AccessTokenAddon for Arc<T> {
 impl<T: AccessTokenAddon + ?Sized> AccessTokenAddon for Rc<T> {
     fn execute(&self, request: &dyn AccessTokenRequest, data: Option<Value>) -> AddonResult {
         (**self).execute(request, data)
+    }
+}
+
+impl<'a, T: ClientCredentialsAddon + ?Sized> ClientCredentialsAddon for &'a T {
+    fn execute(&self, request: &dyn ClientCredentialsRequest) -> AddonResult {
+        (**self).execute(request)
+    }
+}
+
+impl<'a, T: ClientCredentialsAddon + ?Sized> ClientCredentialsAddon for Cow<'a, T>
+where
+    T: Clone + ToOwned,
+{
+    fn execute(&self, request: &dyn ClientCredentialsRequest) -> AddonResult {
+        self.as_ref().execute(request)
+    }
+}
+
+impl<T: ClientCredentialsAddon + ?Sized> ClientCredentialsAddon for Box<T> {
+    fn execute(&self, request: &dyn ClientCredentialsRequest) -> AddonResult {
+        (**self).execute(request)
+    }
+}
+
+impl<T: ClientCredentialsAddon + ?Sized> ClientCredentialsAddon for Arc<T> {
+    fn execute(&self, request: &dyn ClientCredentialsRequest) -> AddonResult {
+        (**self).execute(request)
+    }
+}
+
+impl<T: ClientCredentialsAddon + ?Sized> ClientCredentialsAddon for Rc<T> {
+    fn execute(&self, request: &dyn ClientCredentialsRequest) -> AddonResult {
+        (**self).execute(request)
     }
 }


### PR DESCRIPTION
There's a pattern to take a mutable reference of an endpoint and turning this into a new, modified endpoint.

This however doesn't work as some implementation for &mut AddonList are missing. This change implements those as well.

 - [x] I have read the [contribution guidelines][Contributing]
 - [ ] This change has tests (remove for doc only)
 - [ ] This change has documentation
 - [x] Corresponds to issue (#195 )

I license past and future contributions under the dual MIT/Apache-2.0 license, allowing licensees to chose either at their option.

[Contributing]: CONTRIBUTING.md
