### PR TITLE
Upgrade to axum v0.8

### DIFF
--- a/oxide-auth-axum/Cargo.toml
+++ b/oxide-auth-axum/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT OR Apache-2.0"
 edition = "2021"
 
 [dependencies]
-axum = { version = "0.7", default-features = false, features = [
+axum = { version = "0.8", default-features = false, features = [
     "form",
     "query",
 ] }

--- a/oxide-auth-axum/Cargo.toml
+++ b/oxide-auth-axum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxide-auth-axum"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Daniel Alvsåker <daniel.alvsaaker@protonmail.com>"]
 repository = "https://github.com/HeroicKatora/oxide-auth.git"
 

--- a/oxide-auth-axum/src/request.rs
+++ b/oxide-auth-axum/src/request.rs
@@ -1,6 +1,5 @@
 use oxide_auth::frontends::dev::{NormalizedParameter, QueryParameter, WebRequest};
 use axum::{
-    async_trait,
     extract::{Query, Form, FromRequest, FromRequestParts, Request},
     http::{header, request::Parts},
 };
@@ -80,7 +79,6 @@ impl WebRequest for OAuthRequest {
     }
 }
 
-#[async_trait]
 impl<S> FromRequest<S> for OAuthRequest
 where
     S: Send + Sync,
@@ -113,7 +111,6 @@ where
     }
 }
 
-#[async_trait]
 impl<S> FromRequestParts<S> for OAuthResource
 where
     S: Send + Sync,


### PR DESCRIPTION
This upgrades the axum dependency of `oxide-auth-axum` to v0.8.

I license past and future contributions under the dual MIT/Apache-2.0 license, allowing licensees to chose either at their option.

[Contributing]: CONTRIBUTING.md
