### PR TITLE
Bumpo the version number for oxide-auth-poem to 0.3.0

### DIFF
--- a/oxide-auth-poem/Cargo.toml
+++ b/oxide-auth-poem/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxide-auth-poem"
-version = "0.2.0"
+version = "0.3.0"
 repository = "https://github.com/HeroicKatora/oxide-auth.git"
 authors = ["l1npengtul <l1npengtul@protonmail.com>"]
 description = "A OAuth2 server library for Poem featuring a set of configurable and pluggable backends."


### PR DESCRIPTION
This updates the version number of the oxide-auth-poem subcrate so a new released version can be made available.

 - [x] I have read the [contribution guidelines][Contributing]

I license past and future contributions under the dual MIT/Apache-2.0 license, allowing licensees to chose either at their option.

[Contributing]: CONTRIBUTING.md
