### PR TITLE
Apply oxide-auth-async non-breaking clippy suggested changes

### DIFF
--- a/oxide-auth-async/src/endpoint/access_token.rs
+++ b/oxide-auth-async/src/endpoint/access_token.rs
@@ -283,11 +283,11 @@ impl<R: WebRequest> TokenRequest for WrappedRequest<R> {
         self.error.is_none()
     }
 
-    fn code(&self) -> Option<Cow<str>> {
+    fn code(&self) -> Option<Cow<'_, str>> {
         self.body.unique_value("code")
     }
 
-    fn authorization(&self) -> TokenAuthorization {
+    fn authorization(&self) -> TokenAuthorization<'_> {
         match &self.authorization {
             None => TokenAuthorization::None,
             Some(Authorization(username, None)) => TokenAuthorization::Username(username.into()),
@@ -297,19 +297,19 @@ impl<R: WebRequest> TokenRequest for WrappedRequest<R> {
         }
     }
 
-    fn client_id(&self) -> Option<Cow<str>> {
+    fn client_id(&self) -> Option<Cow<'_, str>> {
         self.body.unique_value("client_id")
     }
 
-    fn redirect_uri(&self) -> Option<Cow<str>> {
+    fn redirect_uri(&self) -> Option<Cow<'_, str>> {
         self.body.unique_value("redirect_uri")
     }
 
-    fn grant_type(&self) -> Option<Cow<str>> {
+    fn grant_type(&self) -> Option<Cow<'_, str>> {
         self.body.unique_value("grant_type")
     }
 
-    fn extension(&self, key: &str) -> Option<Cow<str>> {
+    fn extension(&self, key: &str) -> Option<Cow<'_, str>> {
         self.body.unique_value(key)
     }
 

--- a/oxide-auth-async/src/endpoint/authorization.rs
+++ b/oxide-auth-async/src/endpoint/authorization.rs
@@ -336,27 +336,27 @@ where
         self.error.is_none()
     }
 
-    fn client_id(&self) -> Option<Cow<str>> {
+    fn client_id(&self) -> Option<Cow<'_, str>> {
         self.query.unique_value("client_id")
     }
 
-    fn scope(&self) -> Option<Cow<str>> {
+    fn scope(&self) -> Option<Cow<'_, str>> {
         self.query.unique_value("scope")
     }
 
-    fn redirect_uri(&self) -> Option<Cow<str>> {
+    fn redirect_uri(&self) -> Option<Cow<'_, str>> {
         self.query.unique_value("redirect_uri")
     }
 
-    fn state(&self) -> Option<Cow<str>> {
+    fn state(&self) -> Option<Cow<'_, str>> {
         self.query.unique_value("state")
     }
 
-    fn response_type(&self) -> Option<Cow<str>> {
+    fn response_type(&self) -> Option<Cow<'_, str>> {
         self.query.unique_value("response_type")
     }
 
-    fn extension(&self, key: &str) -> Option<Cow<str>> {
+    fn extension(&self, key: &str) -> Option<Cow<'_, str>> {
         self.query.unique_value(key)
     }
 }

--- a/oxide-auth-async/src/endpoint/client_credentials.rs
+++ b/oxide-auth-async/src/endpoint/client_credentials.rs
@@ -338,21 +338,21 @@ impl<R: WebRequest> ClientCredentialsRequest for WrappedRequest<R> {
         self.error.is_none()
     }
 
-    fn authorization(&self) -> Option<(Cow<str>, Cow<[u8]>)> {
+    fn authorization(&self) -> Option<(Cow<'_, str>, Cow<'_, [u8]>)> {
         self.authorization
             .as_ref()
             .map(|auth| (auth.0.as_str().into(), auth.1.as_slice().into()))
     }
 
-    fn grant_type(&self) -> Option<Cow<str>> {
+    fn grant_type(&self) -> Option<Cow<'_, str>> {
         self.body.unique_value("grant_type")
     }
 
-    fn scope(&self) -> Option<Cow<str>> {
+    fn scope(&self) -> Option<Cow<'_, str>> {
         self.body.unique_value("scope")
     }
 
-    fn extension(&self, key: &str) -> Option<Cow<str>> {
+    fn extension(&self, key: &str) -> Option<Cow<'_, str>> {
         self.body.unique_value(key)
     }
 

--- a/oxide-auth-async/src/endpoint/refresh.rs
+++ b/oxide-auth-async/src/endpoint/refresh.rs
@@ -210,25 +210,25 @@ impl<R: WebRequest> Request for WrappedRequest<R> {
         self.error.is_none()
     }
 
-    fn refresh_token(&self) -> Option<Cow<str>> {
+    fn refresh_token(&self) -> Option<Cow<'_, str>> {
         self.body.unique_value("refresh_token")
     }
 
-    fn authorization(&self) -> Option<(Cow<str>, Cow<[u8]>)> {
+    fn authorization(&self) -> Option<(Cow<'_, str>, Cow<'_, [u8]>)> {
         self.authorization
             .as_ref()
             .map(|auth| (auth.0.as_str().into(), auth.1.as_slice().into()))
     }
 
-    fn scope(&self) -> Option<Cow<str>> {
+    fn scope(&self) -> Option<Cow<'_, str>> {
         self.body.unique_value("scope")
     }
 
-    fn grant_type(&self) -> Option<Cow<str>> {
+    fn grant_type(&self) -> Option<Cow<'_, str>> {
         self.body.unique_value("grant_type")
     }
 
-    fn extension(&self, key: &str) -> Option<Cow<str>> {
+    fn extension(&self, key: &str) -> Option<Cow<'_, str>> {
         self.body.unique_value(key)
     }
 }

--- a/oxide-auth-async/src/endpoint/resource.rs
+++ b/oxide-auth-async/src/endpoint/resource.rs
@@ -156,7 +156,7 @@ impl<R: WebRequest> ResourceRequest for WrappedRequest<R> {
         self.error.is_none()
     }
 
-    fn token(&self) -> Option<Cow<str>> {
+    fn token(&self) -> Option<Cow<'_, str>> {
         self.authorization.as_deref().map(Cow::Borrowed)
     }
 }

--- a/oxide-auth-async/src/tests/mod.rs
+++ b/oxide-auth-async/src/tests/mod.rs
@@ -81,21 +81,21 @@ impl WebRequest for CraftedRequest {
     type Response = CraftedResponse;
     type Error = CraftedError;
 
-    fn query(&mut self) -> Result<Cow<dyn QueryParameter + 'static>, Self::Error> {
+    fn query(&mut self) -> Result<Cow<'_, dyn QueryParameter + 'static>, Self::Error> {
         self.query
             .as_ref()
             .map(|hm| Cow::Borrowed(hm as &dyn QueryParameter))
             .ok_or(CraftedError::Crafted)
     }
 
-    fn urlbody(&mut self) -> Result<Cow<dyn QueryParameter + 'static>, Self::Error> {
+    fn urlbody(&mut self) -> Result<Cow<'_, dyn QueryParameter + 'static>, Self::Error> {
         self.urlbody
             .as_ref()
             .map(|hm| Cow::Borrowed(hm as &dyn QueryParameter))
             .ok_or(CraftedError::Crafted)
     }
 
-    fn authheader(&mut self) -> Result<Option<Cow<str>>, Self::Error> {
+    fn authheader(&mut self) -> Result<Option<Cow<'_, str>>, Self::Error> {
         Ok(self.auth.as_ref().map(|bearer| bearer.as_str().into()))
     }
 }


### PR DESCRIPTION
Apply a series of non-breaking clippy suggestions for oxide-auth-async crate

 - [x] I have read the [contribution guidelines][Contributing]
 - [ ] This change has tests (remove for doc only)
 - [ ] This change has documentation
 - [x] Corresponds to issue #208 

I license past and future contributions under the dual MIT/Apache-2.0 license, allowing licensees to chose either at their option.

[Contributing]: CONTRIBUTING.md
