### PR TITLE
Apply oxide-auth-poem non-breaking clippy suggested changes

### DIFF
--- a/oxide-auth-poem/src/request.rs
+++ b/oxide-auth-poem/src/request.rs
@@ -43,21 +43,21 @@ impl WebRequest for OAuthRequest {
     type Error = OxidePoemError;
     type Response = OAuthResponse;
 
-    fn query(&mut self) -> Result<Cow<dyn QueryParameter + 'static>, Self::Error> {
+    fn query(&mut self) -> Result<Cow<'_, dyn QueryParameter + 'static>, Self::Error> {
         self.query
             .as_ref()
             .map(|q| Cow::Borrowed(q as &dyn QueryParameter))
             .ok_or(OxidePoemError::Request)
     }
 
-    fn urlbody(&mut self) -> Result<Cow<dyn QueryParameter + 'static>, Self::Error> {
+    fn urlbody(&mut self) -> Result<Cow<'_, dyn QueryParameter + 'static>, Self::Error> {
         self.body
             .as_ref()
             .map(|b| Cow::Borrowed(b as &dyn QueryParameter))
             .ok_or(OxidePoemError::Request)
     }
 
-    fn authheader(&mut self) -> Result<Option<Cow<str>>, Self::Error> {
+    fn authheader(&mut self) -> Result<Option<Cow<'_, str>>, Self::Error> {
         Ok(self.auth.as_deref().map(Cow::Borrowed))
     }
 }


### PR DESCRIPTION
Apply a series of non-breaking clippy suggestions for oxide-auth-poem crate

 - [x] I have read the [contribution guidelines][Contributing]
 - [ ] This change has tests (remove for doc only)
 - [ ] This change has documentation
 - [x] Corresponds to issue #208 

I license past and future contributions under the dual MIT/Apache-2.0 license, allowing licensees to chose either at their option.

[Contributing]: CONTRIBUTING.md
