### PR TITLE
Apply oxide-auth-rouille non-breaking clippy suggested changes

### DIFF
--- a/oxide-auth-rouille/src/lib.rs
+++ b/oxide-auth-rouille/src/lib.rs
@@ -9,7 +9,6 @@ use std::borrow::Cow;
 
 use oxide_auth::endpoint::{QueryParameter, WebRequest, WebResponse};
 
-use rouille;
 use url::Url;
 
 // In the spirit of simplicity, this module does not implement any wrapper structures.  In order to


### PR DESCRIPTION
Apply a series of non-breaking clippy suggestions for oxide-auth-rouille crate

 - [x] I have read the [contribution guidelines][Contributing]
 - [ ] This change has tests (remove for doc only)
 - [ ] This change has documentation
 - [x] Corresponds to issue #208 

I license past and future contributions under the dual MIT/Apache-2.0 license, allowing licensees to chose either at their option.

[Contributing]: CONTRIBUTING.md

