### PR TITLE
build(oxide-auth-db): resolve never_type_fallback compilation error

### DIFF
--- a/oxide-auth-db/src/db_service/redis.rs
+++ b/oxide-auth-db/src/db_service/redis.rs
@@ -129,7 +129,7 @@ impl RedisDataSource {
     pub fn regist(&self, detail: &StringfiedEncodedClient) -> anyhow::Result<()> {
         let mut pool = self.pool.get()?;
         let client_str = serde_json::to_string(&detail)?;
-        pool.set(&(self.client_prefix.to_owned() + &detail.client_id), client_str)?;
+        pool.set::<_, _, ()>(&(self.client_prefix.to_owned() + &detail.client_id), client_str)?;
         Ok(())
     }
 }


### PR DESCRIPTION
This allows oxide-auth-db to compiles.

 - [x] I have read the [contribution guidelines][Contributing]
 - [ ] This change has tests (remove for doc only)
 - [ ] This change has documentation
 - [x] Corresponds to #219

I license past and future contributions under the dual MIT/Apache-2.0 license, allowing licensees to chose either at their option.

[Contributing]: CONTRIBUTING.md