### PR TITLE
build(oxide-auth-iron): resolve iron example build error

### DIFF
--- a/oxide-auth-actix/examples/actix-example/src/support.rs
+++ b/oxide-auth-actix/examples/actix-example/src/support.rs
@@ -4,7 +4,7 @@ mod generic;
 
 use std::collections::HashMap;
 
-pub use self::generic::{consent_page_html, open_in_browser, Client, ClientConfig, ClientError};
+pub use self::generic::{consent_page_html, open_in_browser, Client, ClientConfig};
 
 use actix_web::{
     App, dev,

--- a/oxide-auth-iron/examples/iron.rs
+++ b/oxide-auth-iron/examples/iron.rs
@@ -6,7 +6,7 @@ extern crate router;
 use std::sync::{Arc, Mutex};
 use std::thread::spawn;
 
-use iron::{Iron, Request, Response};
+use iron::{Iron, IronError, Request, Response};
 use iron::headers::ContentType;
 use iron::status::Status;
 use iron::middleware::Handler;
@@ -44,7 +44,7 @@ fn main_router() -> impl Handler + 'static {
                 .execute(request.into())
                 .map_err(|e| {
                     let e: OAuthError = e.into();
-                    e.into()
+                    IronError::from(e)
                 })?;
             Ok(response.into())
         },
@@ -61,7 +61,7 @@ fn main_router() -> impl Handler + 'static {
                 .execute(request.into())
                 .map_err(|e| {
                     let e: OAuthError = e.into();
-                    e.into()
+                    IronError::from(e)
                 })?;
             Ok(response.into())
         },
@@ -77,7 +77,7 @@ fn main_router() -> impl Handler + 'static {
                 .execute(request.into())
                 .map_err(|e| {
                     let e: OAuthError = e.into();
-                    e.into()
+                    IronError::from(e)
                 })?;
             Ok(response.into())
         },


### PR DESCRIPTION
This change addresses a build error in the iron example.

 - [x] I have read the [contribution guidelines][Contributing]
 - [ ] This change has tests (remove for doc only)
 - [ ] This change has documentation
 - [x] Corresponds to #219

I license past and future contributions under the dual MIT/Apache-2.0 license, allowing licensees to chose either at their option.

[Contributing]: CONTRIBUTING.md