### PR TITLE
fmt: apply formatting corrections

### DIFF
--- a/examples/support/client.rs
+++ b/examples/support/client.rs
@@ -75,16 +75,16 @@ struct TokenMap {
 
     scope: Option<String>,
 
-    #[serde(skip_serializing_if="Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     access_token: Option<String>,
 
-    #[serde(skip_serializing_if="Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     refresh_token: Option<String>,
 
-    #[serde(skip_serializing_if="Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     expires_in: Option<i64>,
 
-    #[serde(skip_serializing_if="Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     error: Option<String>,
 }
 
@@ -106,20 +106,17 @@ impl Client {
         params.insert("grant_type", "authorization_code");
         params.insert("code", code);
         params.insert("redirect_uri", &self.config.redirect_uri);
-        let access_token_request =  match &self.config.client_secret{
+        let access_token_request = match &self.config.client_secret {
             Some(client_secret) => client
                 .post(&self.config.token_url)
                 .form(&params)
                 .basic_auth(&self.config.client_id, client_secret.get_unique())
-                .build().unwrap(),
-            None =>{
+                .build()
+                .unwrap(),
+            None => {
                 params.insert("client_id", &self.config.client_id);
-                client
-                .post(&self.config.token_url)
-                .form(&params)
-                .build().unwrap()
+                client.post(&self.config.token_url).form(&params).build().unwrap()
             }
-
         };
 
         let token_response = client
@@ -176,7 +173,6 @@ impl Client {
             None => return Err(Error::NoToken),
         };
 
-
         let mut params = HashMap::new();
         params.insert("grant_type", "refresh_token");
         params.insert("refresh_token", &refresh);
@@ -186,15 +182,16 @@ impl Client {
                 .post(&self.config.refresh_url)
                 .form(&params)
                 .basic_auth(&self.config.client_id, client_secret.get_unique())
-                .build().unwrap(),
+                .build()
+                .unwrap(),
             None => {
                 params.insert("client_id", &self.config.client_id);
                 client
                     .post(&self.config.refresh_url)
                     .form(&params)
-                    .build().unwrap()
+                    .build()
+                    .unwrap()
             }
-
         };
         let token_response = client
             .execute(access_token_request)
@@ -205,15 +202,10 @@ impl Client {
             return Err(Error::MissingToken);
         }
 
-        let token = token_map
-            .access_token
-            .unwrap();
+        let token = token_map.access_token.unwrap();
         state.token = Some(token);
-        state.refresh = token_map
-            .refresh_token
-            .or(state.refresh.take());
-        state.until = token_map
-            .expires_in;
+        state.refresh = token_map.refresh_token.or(state.refresh.take());
+        state.until = token_map.expires_in;
         Ok(())
     }
 

--- a/examples/support/generic.rs
+++ b/examples/support/generic.rs
@@ -11,7 +11,7 @@
 #![allow(unused)]
 
 /// Simplistic reqwest client.
-#[path="./client.rs"]
+#[path = "./client.rs"]
 mod client;
 
 use oxide_auth::endpoint::Solicitation;
@@ -54,7 +54,7 @@ pub fn open_in_browser(port: u16) {
 pub fn consent_page_html(route: &str, solicitation: Solicitation) -> String {
     macro_rules! template {
         () => {
-"<html>'{0:}' (at {1:}) is requesting permission for '{2:}'
+            "<html>'{0:}' (at {1:}) is requesting permission for '{2:}'
 <form method=\"post\">
     <input type=\"submit\" value=\"Accept\" formaction=\"{4:}?{3:}&allow=true\">
     <input type=\"submit\" value=\"Deny\" formaction=\"{4:}?{3:}&deny=true\">
@@ -75,8 +75,9 @@ pub fn consent_page_html(route: &str, solicitation: Solicitation) -> String {
     if let Some(state) = state {
         extra.push(("state", state));
     }
-    
-    format!(template!(), 
+
+    format!(
+        template!(),
         grant.client_id,
         grant.redirect_uri,
         grant.scope,

--- a/examples/support/iron.rs
+++ b/examples/support/iron.rs
@@ -29,17 +29,23 @@ pub fn dummy_client() -> impl Handler + 'static {
     let get_state = Arc::new(State::default());
     let endpoint_state = get_state.clone();
     let mut router = router::Router::new();
-    router.get("/endpoint", move |request: &mut Request| endpoint(get_state.clone(), request), "endpoint");
-    router.get("/", move |request: &mut Request| view(endpoint_state.clone(), request), "view");
+    router.get(
+        "/endpoint",
+        move |request: &mut Request| endpoint(get_state.clone(), request),
+        "endpoint",
+    );
+    router.get(
+        "/",
+        move |request: &mut Request| view(endpoint_state.clone(), request),
+        "view",
+    );
     router
 }
 
 /// Receive the authorization codes at 'http://localhost:8021/endpoint'.
 fn endpoint(state: Arc<State>, req: &mut Request) -> IronResult<Response> {
     // Check the received parameters in the input
-    let query = req.url.as_ref()
-        .query_pairs()
-        .collect::<HashMap<_, _>>();
+    let query = req.url.as_ref().query_pairs().collect::<HashMap<_, _>>();
 
     if let Some(error) = query.get("error") {
         let message = format!("Error during owner authorization: {}", error.as_ref());
@@ -48,7 +54,7 @@ fn endpoint(state: Arc<State>, req: &mut Request) -> IronResult<Response> {
 
     let code = match query.get("code") {
         None => return Ok(Response::with((Status::BadRequest, "Missing code"))),
-        Some(v) => v.clone()
+        Some(v) => v.clone(),
     };
 
     // Construct a request against http://localhost:8020/token, the access token endpoint
@@ -60,17 +66,29 @@ fn endpoint(state: Arc<State>, req: &mut Request) -> IronResult<Response> {
     params.insert("redirect_uri", "http://localhost:8021/endpoint");
     let access_token_request = client
         .post("http://localhost:8020/token")
-        .form(&params).build().unwrap();
+        .form(&params)
+        .build()
+        .unwrap();
     let mut token_response = match client.execute(access_token_request) {
         Ok(response) => response,
-        Err(_) => return Ok(Response::with((Status::InternalServerError, "Could not fetch bearer token"))),
+        Err(_) => {
+            return Ok(Response::with((
+                Status::InternalServerError,
+                "Could not fetch bearer token",
+            )))
+        }
     };
 
     let mut token = String::new();
     token_response.read_to_string(&mut token).unwrap();
     let token_map: HashMap<String, String> = match serde_json::from_str(&token) {
         Ok(response) => response,
-        Err(err) => return Ok(Response::with((Status::BadRequest, format!("Could not parse token response {:?}", err)))),
+        Err(err) => {
+            return Ok(Response::with((
+                Status::BadRequest,
+                format!("Could not parse token response {:?}", err),
+            )))
+        }
     };
 
     if token_map.get("error").is_some() {
@@ -111,11 +129,17 @@ fn view(state: Arc<State>, _: &mut Request) -> IronResult<Response> {
     let page_request = client
         .get("http://localhost:8020/")
         .header(header::AUTHORIZATION, format!("Bearer {}", token))
-        .build().unwrap();
+        .build()
+        .unwrap();
 
     let mut page_response = match client.execute(page_request) {
         Ok(response) => response,
-        Err(_) => return Ok(Response::with((Status::BadRequest, "Could not access protected resource"))),
+        Err(_) => {
+            return Ok(Response::with((
+                Status::BadRequest,
+                "Could not access protected resource",
+            )))
+        }
     };
 
     let mut protected_page = String::new();

--- a/examples/support/rouille.rs
+++ b/examples/support/rouille.rs
@@ -4,7 +4,7 @@ extern crate serde_urlencoded;
 extern crate serde;
 extern crate serde_json;
 
-#[path="generic.rs"]
+#[path = "generic.rs"]
 mod generic;
 
 pub use self::generic::{Client, ClientConfig, ClientError};
@@ -12,16 +12,14 @@ pub use self::generic::{consent_page_html, open_in_browser};
 
 use self::rouille::{Request, Response};
 
-pub fn dummy_client()
-    -> impl (Fn(&Request) -> Response) + 'static
-{
+pub fn dummy_client() -> impl (Fn(&Request) -> Response) + 'static {
     let client = Client::new(ClientConfig {
         client_id: "LocalClient".into(),
         protected_url: "http://localhost:8020/".into(),
         token_url: "http://localhost:8020/token".into(),
         refresh_url: "http://localhost:8020/refresh".into(),
         redirect_uri: "http://localhost:8021/endpoint".into(),
-        client_secret: None
+        client_secret: None,
     });
 
     move |request| {
@@ -60,8 +58,7 @@ pub fn client_impl(client: &Client, _: &Request) -> Response {
         <form action=\"/refresh\" method=\"post\"><button>Refresh token</button></form>
         </main></html>", client.as_html(), protected_page);
 
-    Response::html(display_page)
-        .with_status_code(200)
+    Response::html(display_page).with_status_code(200)
 }
 
 fn endpoint_impl(client: &Client, request: &Request) -> Response {
@@ -72,8 +69,9 @@ fn endpoint_impl(client: &Client, request: &Request) -> Response {
 
     let code = match request.get_param("code") {
         Some(code) => code,
-        None => return Response::text("Endpoint hit without an authorization code")
-            .with_status_code(400),
+        None => {
+            return Response::text("Endpoint hit without an authorization code").with_status_code(400)
+        }
     };
 
     if let Err(err) = client.authorize(&code) {
@@ -84,7 +82,8 @@ fn endpoint_impl(client: &Client, request: &Request) -> Response {
 }
 
 fn refresh_impl(client: &Client, _: &Request) -> Response {
-    client.refresh()
+    client
+        .refresh()
         .err()
         .map_or_else(|| Response::redirect_303("/"), internal_error)
 }

--- a/oxide-auth-actix/examples/actix-example/src/support.rs
+++ b/oxide-auth-actix/examples/actix-example/src/support.rs
@@ -1,4 +1,3 @@
-#[rustfmt::skip]
 #[path = "../../../../examples/support/generic.rs"]
 mod generic;
 

--- a/oxide-auth-db/examples/db-example/src/support.rs
+++ b/oxide-auth-db/examples/db-example/src/support.rs
@@ -1,4 +1,3 @@
-#[rustfmt::skip]
 #[path = "../../../../examples/support/generic.rs"]
 mod generic;
 

--- a/oxide-auth-iron/examples/iron.rs
+++ b/oxide-auth-iron/examples/iron.rs
@@ -16,7 +16,6 @@ use oxide_auth::frontends::simple::endpoint::{FnSolicitor, Generic, Vacant};
 use oxide_auth::primitives::prelude::*;
 use oxide_auth_iron::{OAuthRequest, OAuthResponse, OAuthError};
 
-#[rustfmt::skip]
 #[path = "../../examples/support/iron.rs"]
 mod support;
 

--- a/oxide-auth-rocket/examples/rocket.rs
+++ b/oxide-auth-rocket/examples/rocket.rs
@@ -5,7 +5,6 @@ extern crate oxide_auth_rocket;
 #[macro_use]
 extern crate rocket;
 
-#[rustfmt::skip]
 #[path = "../../examples/support/rocket.rs"]
 mod support;
 

--- a/oxide-auth-rouille/examples/rouille.rs
+++ b/oxide-auth-rouille/examples/rouille.rs
@@ -1,7 +1,6 @@
 #[macro_use]
 extern crate rouille;
 
-#[rustfmt::skip]
 #[path = "../../examples/support/rouille.rs"]
 mod support;
 


### PR DESCRIPTION
This change applies cargo fmt to the whole repository and removes the skip directives for fmt.

 - [x] I have read the [contribution guidelines][Contributing]
 - [ ] This change has tests (remove for doc only)
 - [ ] This change has documentation
 - [ ] Corresponds to issue (number)

I license past and future contributions under the dual MIT/Apache-2.0 license, allowing licensees to chose either at their option.

[Contributing]: CONTRIBUTING.md
