### PR TITLE
Apply oxide-auth-rouille non-breaking clippy suggested changes

### DIFF
--- a/oxide-auth-rouille/examples/rouille.rs
+++ b/oxide-auth-rouille/examples/rouille.rs
@@ -140,7 +140,7 @@ fn solicitor(request: &mut Request, grant: Solicitation<'_>) -> OwnerConsent<OAu
         OwnerConsent::InProgress(response.into())
     } else if request.method() == "POST" {
         // No real user authentication is done here, in production you MUST use session keys or equivalent
-        if let Some(_) = request.get_param("allow") {
+        if request.get_param("allow").is_some() {
             OwnerConsent::Authorized("dummy user".to_string())
         } else {
             OwnerConsent::Denied


### PR DESCRIPTION
Apply a series of non-breaking clippy suggestions for oxide-auth-rouille crate

 - [x] I have read the [contribution guidelines][Contributing]
 - [ ] This change has tests (remove for doc only)
 - [ ] This change has documentation
 - [x] Corresponds to issue #208 

I license past and future contributions under the dual MIT/Apache-2.0 license, allowing licensees to chose either at their option.

[Contributing]: CONTRIBUTING.md
