### PR TITLE
test(oxide-auth): fix doc tests for oxide-auth crate

### DIFF
--- a/oxide-auth/src/primitives/issuer.rs
+++ b/oxide-auth/src/primitives/issuer.rs
@@ -199,6 +199,7 @@ impl IssuedToken {
     /// # use oxide_auth::primitives::issuer::RefreshedToken;
     /// use oxide_auth::primitives::grant::Grant;
     /// use oxide_auth::primitives::issuer::{Issuer, IssuedToken};
+    /// use oxide_auth::OAuthOpaqueError;
     ///
     /// struct MyIssuer;
     ///
@@ -210,14 +211,14 @@ impl IssuedToken {
     /// }
     ///
     /// impl Issuer for MyIssuer {
-    ///     fn issue(&mut self, mut grant: Grant) -> Result<IssuedToken, ()> {
+    ///     fn issue(&mut self, mut grant: Grant) -> Result<IssuedToken, OAuthOpaqueError> {
     ///         let token = self.access_token(&grant);
     ///         Ok(IssuedToken::without_refresh(token, grant.until))
     ///     }
     ///     // …
-    /// # fn recover_token<'t>(&'t self, token: &'t str) -> Result<Option<Grant>, ()> { Err(()) }
-    /// # fn recover_refresh<'t>(&'t self, token: &'t str) -> Result<Option<Grant>, ()> { Err(()) }
-    /// # fn refresh(&mut self, _: &str, _: Grant) -> Result<RefreshedToken, ()> { Err(()) }
+    /// # fn recover_token<'t>(&'t self, token: &'t str) -> Result<Option<Grant>, OAuthOpaqueError> { Err(OAuthOpaqueError) }
+    /// # fn recover_refresh<'t>(&'t self, token: &'t str) -> Result<Option<Grant>, OAuthOpaqueError> { Err(OAuthOpaqueError) }
+    /// # fn refresh(&mut self, _: &str, _: Grant) -> Result<RefreshedToken, OAuthOpaqueError> { Err(OAuthOpaqueError) }
     /// }
     /// ```
     pub fn without_refresh(token: String, until: Time) -> Self {


### PR DESCRIPTION
As part of the changes in #235, doc tests for oxide-auth crate were left out. This change addresses those errors.

 - [x] I have read the [contribution guidelines][Contributing]
 - [ ] This change has tests (remove for doc only)
 - [ ] This change has documentation
 - [x] Corresponds to issue #208

I license past and future contributions under the dual MIT/Apache-2.0 license, allowing licensees to chose either at their option.

[Contributing]: CONTRIBUTING.md
